### PR TITLE
docs: add AGENTS.md and update README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+# AGENTS.md
+
+Guidelines for AI coding agents working in this repository.
+
+## What this repo is
+
+A pnpm monorepo of [pi coding agent](https://github.com/earendil-works/pi) extensions. Each package under `packages/` is a self-contained pi extension that can be installed by users into their pi config.
+
+## Packages
+
+### `fence-pi` (`packages/fence-pi`)
+Hooks into pi's `tool_call` / `tool_result` events to detect decorative fence/divider comments being written (e.g. `// ---- section ----`, `// ===== Title =====`). Operates in three modes controlled by the `fence-pi-mode` flag:
+
+- **warn** (default) — appends a warning to the tool result after writing
+- **block** — returns `{ block: true }` before the write happens
+- **remove** — strips the fence comments from the content before writing
+
+Uses [tree-sitter](https://tree-sitter.github.io/) to parse comment nodes. Supports JS/TS, Python, Go, and Rust.
+
+### `sem-pi` (`packages/sem-pi`) — private
+Wraps the [`sem`](https://github.com/piotr-oles/sem) CLI as four pi tools: `sem_context`, `sem_entities`, `sem_impact`, `sem_diff`. Gives the model semantic understanding of code structure without reading entire files.
+
+## Tech stack
+
+- **Runtime**: Node.js ≥ 22.19.0, ESM throughout (`"type": "module"`)
+- **Language**: TypeScript 5, strict
+- **Package manager**: pnpm 10 with workspaces
+- **Linter/formatter**: Biome
+- **Tests**: Vitest
+- **Releases**: Changesets (only `fence-pi` is published; `sem-pi` is private)
+
+## Development commands
+
+```bash
+pnpm install                  # install workspace deps
+pnpm test                     # run all tests across packages
+pnpm typecheck                # tsc --noEmit across packages
+pnpm check                    # biome ci (lint + format check)
+pnpm lint:fix                 # auto-fix lint
+pnpm format                   # auto-format
+```
+
+Per-package (from `packages/<name>/`):
+
+```bash
+pnpm test:watch               # vitest watch mode
+pnpm test:coverage            # coverage report
+```
+
+## Conventions
+
+### No fence/divider comments
+`fence-pi` itself is active in this repo. Do not write decorative separator comments like:
+
+```ts
+// ---- helpers ----
+// ===== Section =====
+// *** utilities ***
+```
+
+Use named functions, classes, or blank lines to separate logical sections instead.
+
+### ESM imports require `.js` extensions
+All local imports must use `.js` extensions (compiled output convention), even though the source files are `.ts`:
+
+```ts
+import { isFenceComment } from "./fence.js";  // correct
+import { isFenceComment } from "./fence.ts";  // wrong
+import { isFenceComment } from "./fence";     // wrong
+```
+
+### Biome for formatting and linting
+Do not configure Prettier or ESLint. All formatting and linting goes through Biome (`biome.json` at root).
+
+## Extension entry point contract
+
+Each package's `src/index.ts` must `export default` a function with the signature:
+
+```ts
+export default function myExtension(pi: ExtensionAPI): void { ... }
+```
+
+This is what pi loads from the `"pi": { "extensions": [...] }` field in `package.json`.
+
+## Testing approach
+
+Tests live in `src/tests/` inside each package. Vitest is the test runner.
+
+`sem-pi` uses three layers:
+- **Unit** — tool logic with `exec` mocked via `vi.fn()`
+- **Integration** — real pi runtime + mocked `sem` subprocess
+- **Smoke** — `npm pack` → install → load in real pi
+
+`fence-pi` uses the [`@marcfargas/pi-test-harness`](https://www.npmjs.com/package/@marcfargas/pi-test-harness) package to simulate pi events against the extension.
+
+## Adding a new package
+
+1. `mkdir packages/<name>`
+2. `packages/<name>/package.json` — include:
+   - `"type": "module"`
+   - `"pi": { "extensions": ["./src/index.ts"] }`
+   - scripts: `test`, `typecheck`, `check`, `lint:fix`, `format`
+3. `packages/<name>/tsconfig.json` — extend `../../tsconfig.base.json`
+4. `packages/<name>/src/index.ts` — default-export a function `(pi: ExtensionAPI) => void`
+5. CI picks it up automatically via `pnpm -r`
+
+For publishable packages, also add `"publishConfig": { "access": "public" }` and `"files"` to `package.json`. Private packages set `"private": true`.
+
+## CI
+
+`.github/workflows/ci.yml` — runs `test`, `typecheck`, `check` on every PR.  
+`.github/workflows/release.yml` — Changesets release flow on `main`: opens a Version Packages PR while changesets are pending, publishes to npm once merged.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A monorepo of [pi coding agent](https://github.com/earendil-works/pi) extensions
 
 | Package | Description |
 |---------|-------------|
-| [`@piotr-oles/sem-pi`](packages/sem-pi) | Exposes [sem](https://github.com/Ata1.raxy-Labs/sem) as agent tools — semantic code navigation without reading entire files |
+| [`fence-pi`](packages/fence-pi) | Detects and handles decorative fence/divider comments in written code — warn, block, or auto-remove |
+| [`sem-pi`](packages/sem-pi) *(private)* | Exposes [sem](https://github.com/piotr-oles/sem) as agent tools — semantic code navigation without reading entire files |
 
 ## Development
 
@@ -27,6 +28,16 @@ Each package has its own `README.md` with installation and usage instructions.
 2. Add a `package.json` with a `"pi": { "extensions": ["./src/index.ts"] }` field and the standard scripts (`test`, `typecheck`, `check`)
 3. Add a `tsconfig.json` extending `../../tsconfig.base.json`
 4. CI picks it up automatically via `pnpm -r`
+
+## Releases
+
+Published packages are released via [Changesets](https://github.com/changesets/changesets). To cut a release:
+
+```bash
+pnpm changeset       # describe your change
+pnpm version         # bump versions + update changelogs
+# merge the Version Packages PR → CI publishes to npm automatically
+```
 
 ## License
 

--- a/packages/fence-pi/package.json
+++ b/packages/fence-pi/package.json
@@ -2,6 +2,7 @@
   "name": "fence-pi",
   "version": "0.1.1",
   "description": "Pi Agent extension: block or warn on fence/divider comments in written code",
+  "keywords": ["pi-package"],
   "type": "module",
   "files": [
     "src",
@@ -32,6 +33,10 @@
     "tree-sitter-python": "^0.25.0",
     "tree-sitter-go": "^0.25.0",
     "tree-sitter-rust": "^0.24.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
     "@earendil-works/pi-agent-core": "^0.75.5",

--- a/packages/fence-pi/package.json
+++ b/packages/fence-pi/package.json
@@ -2,7 +2,9 @@
   "name": "fence-pi",
   "version": "0.1.1",
   "description": "Pi Agent extension: block or warn on fence/divider comments in written code",
-  "keywords": ["pi-package"],
+  "keywords": [
+    "pi-package"
+  ],
   "type": "module",
   "files": [
     "src",


### PR DESCRIPTION
- Add `AGENTS.md` with guidelines for AI coding agents (package descriptions, conventions, ESM import rules, testing approach, extension contract, adding new packages)
- Update `README.md`: add `fence-pi` to the packages table (was missing), mark `sem-pi` as private, add Releases section