### PR TITLE
docs(pi-fence): add README

### DIFF
--- a/packages/pi-fence/README.md
+++ b/packages/pi-fence/README.md
@@ -29,7 +29,7 @@ JS, TS, Python, Go, Rust.
 
 ## Modes
 
-Control via `pi-fence-mode` flag:
+Control via `pi-fence-mode` flag passed as CLI arg:
 
 | Mode | Behavior |
 |------|----------|
@@ -37,15 +37,6 @@ Control via `pi-fence-mode` flag:
 | `block` | Write blocked, model must retry without fences |
 | `remove` | Fence comments stripped before write |
 
-Set in pi config:
-
-```json
-{
-  "flags": {
-    "pi-fence-mode": "block"
-  }
-}
-```
 
 ## How it works
 

--- a/packages/pi-fence/README.md
+++ b/packages/pi-fence/README.md
@@ -1,0 +1,52 @@
+# pi-fence
+
+Pi extension. Detect decorative fence/divider comments in written code. Warn, block, or strip them.
+
+## What it catches
+
+```ts
+// ---- helpers ----
+// ===== Section =====
+// *** utilities ***
+# ################
+```
+
+New fences only. Pre-existing comments ignored.
+
+## Supported languages
+
+JS, TS, Python, Go, Rust.
+
+## Install
+
+```json
+{
+  "pi": {
+    "extensions": ["pi-fence"]
+  }
+}
+```
+
+## Modes
+
+Control via `pi-fence-mode` flag:
+
+| Mode | Behavior |
+|------|----------|
+| `warn` (default) | Write proceeds, warning appended to tool result |
+| `block` | Write blocked, model must retry without fences |
+| `remove` | Fence comments stripped before write |
+
+Set in pi config:
+
+```json
+{
+  "flags": {
+    "pi-fence-mode": "block"
+  }
+}
+```
+
+## How it works
+
+Hooks `tool_call` / `tool_result` on `write` and `edit` tools. Parses new content with tree-sitter. Compares against existing file — only newly introduced fences trigger. Acts per mode.


### PR DESCRIPTION
Add README to pi-fence package with caveman-style description covering install, modes, supported languages, and how it works.