### PR TITLE
feat(pi-fence): messages.ts, compact findings format, mode integration tests

### DIFF
--- a/packages/pi-fence/src/index.ts
+++ b/packages/pi-fence/src/index.ts
@@ -7,7 +7,9 @@ import {
   isWriteToolResult,
 } from "@earendil-works/pi-coding-agent";
 import { isFenceComment, removeFenceComments } from "./fence.js";
+import { buildBlockReason, buildRemoveText, buildWarnText } from "./messages.js";
 import { type CommentNode, extractComments } from "./parse.js";
+import type { Finding } from "./types.js";
 
 const PROMPT_INSTRUCTIONS = `
 Do not insert decorative fence or divider comments like:
@@ -17,11 +19,6 @@ Do not insert decorative fence or divider comments like:
   # ################
 Use named functions, classes, or blank lines to separate code sections instead.
 `.trim();
-
-interface Finding {
-  relativePath: string;
-  fences: CommentNode[];
-}
 
 type FenceMode = "warn" | "block" | "remove";
 
@@ -72,6 +69,7 @@ export default function piFence(pi: ExtensionAPI) {
       }
       if (mode === "remove") {
         event.input.content = removeFenceComments(event.input.content, fences);
+        pendingFindings.set(event.toolCallId, { relativePath, fences });
         return undefined;
       }
       if (mode === "block") {
@@ -104,22 +102,21 @@ export default function piFence(pi: ExtensionAPI) {
         return undefined;
       }
 
-      if (mode === "remove") {
-        // Lines in each fences array are relative to the edit fragment —
-        // no offset needed; just mutate newText in place.
-        for (const { edit, fences } of perEdit) {
-          edit.newText = removeFenceComments(edit.newText, fences);
-        }
-        return undefined;
-      }
-
-      // block / warn: flatten with file-level line offsets.
+      // Flatten fences with file-level line offsets for all modes.
       const allFences: CommentNode[] = [];
       for (const { edit, fences } of perEdit) {
         const lineOffset = oldContent ? findStartLine(oldContent, edit.oldText) - 1 : 0;
         for (const c of fences) {
           allFences.push({ ...c, startLine: c.startLine + lineOffset });
         }
+      }
+
+      if (mode === "remove") {
+        for (const { edit, fences } of perEdit) {
+          edit.newText = removeFenceComments(edit.newText, fences);
+        }
+        pendingFindings.set(event.toolCallId, { relativePath, fences: allFences });
+        return undefined;
       }
 
       if (mode === "block") {
@@ -147,9 +144,11 @@ export default function piFence(pi: ExtensionAPI) {
 
     // Append the warning to the tool result content so the model sees it
     // inline, alongside the write confirmation, without a separate turn.
+    const mode = resolveMode(pi.getFlag("pi-fence-mode"));
+    const text = mode === "remove" ? buildRemoveText([finding]) : buildWarnText([finding]);
     const warning: { type: "text"; text: string } = {
       type: "text",
-      text: buildWarnText([finding]),
+      text,
     };
     return { content: [...event.content, warning] };
   });
@@ -170,28 +169,4 @@ function findStartLine(haystack: string, needle: string): number {
     return 1;
   }
   return haystack.slice(0, idx).split("\n").length;
-}
-
-function formatFinding(f: CommentNode): string {
-  return `    line ${f.startLine}, col ${f.startCol + 1}: ${f.text.trim()}`;
-}
-
-function buildBlockReason(findings: Finding[]): string {
-  const lines = ["Write blocked — fence/divider comments in added code:"];
-  for (const { relativePath, fences } of findings) {
-    lines.push(`  ${relativePath}:`);
-    lines.push(...fences.map(formatFinding));
-  }
-  lines.push("Remove these comments and retry.");
-  return lines.join("\n");
-}
-
-function buildWarnText(findings: Finding[]): string {
-  const lines = ["⚠ pi-fence: fence/divider comments detected in added code:"];
-  for (const { relativePath, fences } of findings) {
-    lines.push(`  ${relativePath}:`);
-    lines.push(...fences.map(formatFinding));
-  }
-  lines.push("Please remove them.");
-  return lines.join("\n");
 }

--- a/packages/pi-fence/src/messages.ts
+++ b/packages/pi-fence/src/messages.ts
@@ -1,0 +1,39 @@
+import type { CommentNode } from "./parse.js";
+import type { Finding } from "./types.js";
+
+export function formatFinding(f: CommentNode): string {
+  return `    line ${f.startLine}, col ${f.startCol + 1}: ${f.text.trim()}`;
+}
+
+export function buildFindingLines(findings: Finding[]): string[] {
+  const lines: string[] = [];
+  for (const { relativePath, fences } of findings) {
+    lines.push(`  ${relativePath}:`);
+    lines.push(...fences.map(formatFinding));
+  }
+  return lines;
+}
+
+export function buildBlockReason(findings: Finding[]): string {
+  return [
+    "Write blocked — fence/divider comments in added code:",
+    ...buildFindingLines(findings),
+    "Remove these comments and retry.",
+  ].join("\n");
+}
+
+export function buildWarnText(findings: Finding[]): string {
+  return [
+    "⚠ pi-fence: fence/divider comments detected in added code:",
+    ...buildFindingLines(findings),
+    "Please remove them.",
+  ].join("\n");
+}
+
+export function buildRemoveText(findings: Finding[]): string {
+  return [
+    "ℹ pi-fence: fence/divider comments were automatically removed:",
+    ...buildFindingLines(findings),
+    "Do not add them back.",
+  ].join("\n");
+}

--- a/packages/pi-fence/src/messages.ts
+++ b/packages/pi-fence/src/messages.ts
@@ -1,15 +1,19 @@
 import type { CommentNode } from "./parse.js";
 import type { Finding } from "./types.js";
 
-export function formatFinding(f: CommentNode): string {
-  return `    line ${f.startLine}, col ${f.startCol + 1}: ${f.text.trim()}`;
-}
-
 export function buildFindingLines(findings: Finding[]): string[] {
+  function formatFinding({ startLine, startCol, text }: CommentNode): string {
+    return `${startLine}:${startCol + 1}: ${text.trimEnd()}`;
+  }
+
   const lines: string[] = [];
   for (const { relativePath, fences } of findings) {
-    lines.push(`  ${relativePath}:`);
-    lines.push(...fences.map(formatFinding));
+    if (fences.length === 1) {
+      lines.push(`${relativePath.padStart(2)}:${formatFinding(fences[0])}`);
+    } else {
+      lines.push(`${relativePath.padStart(2)}:`);
+      lines.push(...fences.map((f) => formatFinding(f).padStart(4)));
+    }
   }
   return lines;
 }

--- a/packages/pi-fence/src/messages.ts
+++ b/packages/pi-fence/src/messages.ts
@@ -9,10 +9,10 @@ export function buildFindingLines(findings: Finding[]): string[] {
   const lines: string[] = [];
   for (const { relativePath, fences } of findings) {
     if (fences.length === 1) {
-      lines.push(`${relativePath.padStart(2)}:${formatFinding(fences[0])}`);
+      lines.push(`  ${relativePath}:${formatFinding(fences[0])}`);
     } else {
-      lines.push(`${relativePath.padStart(2)}:`);
-      lines.push(...fences.map((f) => formatFinding(f).padStart(4)));
+      lines.push(`  ${relativePath}:`);
+      lines.push(...fences.map((f) => `    ${formatFinding(f)}`));
     }
   }
   return lines;

--- a/packages/pi-fence/src/tests/messages.test.ts
+++ b/packages/pi-fence/src/tests/messages.test.ts
@@ -4,7 +4,6 @@ import {
   buildFindingLines,
   buildRemoveText,
   buildWarnText,
-  formatFinding,
 } from "../messages.js";
 import type { CommentNode } from "../parse.js";
 import type { Finding } from "../types.js";
@@ -17,26 +16,6 @@ function finding(relativePath: string, fences: CommentNode[]): Finding {
   return { relativePath, fences };
 }
 
-describe("formatFinding", () => {
-  it("formats line and col (1-indexed) with trimmed text", () => {
-    expect(formatFinding(node("// ---- section ----", 3, 0))).toMatchInlineSnapshot(
-      `"    line 3, col 1: // ---- section ----"`,
-    );
-  });
-
-  it("adjusts col to 1-indexed", () => {
-    expect(formatFinding(node("// ===", 10, 4))).toMatchInlineSnapshot(
-      `"    line 10, col 5: // ==="`,
-    );
-  });
-
-  it("trims surrounding whitespace from the comment text", () => {
-    expect(formatFinding(node("  // --- trim me ---  ", 1))).toMatchInlineSnapshot(
-      `"    line 1, col 1: // --- trim me ---"`,
-    );
-  });
-});
-
 describe("buildFindingLines", () => {
   it("returns empty array for empty findings", () => {
     expect(buildFindingLines([])).toMatchInlineSnapshot(`[]`);
@@ -45,8 +24,7 @@ describe("buildFindingLines", () => {
   it("formats a single file with one fence", () => {
     expect(buildFindingLines([finding("src/foo.ts", [node("// ----", 2)])])).toMatchInlineSnapshot(`
       [
-        "  src/foo.ts:",
-        "    line 2, col 1: // ----",
+        "  src/foo.ts:2:1: // ----",
       ]
     `);
   });
@@ -57,8 +35,8 @@ describe("buildFindingLines", () => {
     ).toMatchInlineSnapshot(`
       [
         "  src/bar.ts:",
-        "    line 1, col 1: // ====",
-        "    line 5, col 1: // ####",
+        "    1:1: // ====",
+        "    5:1: // ####",
       ]
     `);
   });
@@ -71,10 +49,8 @@ describe("buildFindingLines", () => {
       ]),
     ).toMatchInlineSnapshot(`
       [
-        "  a.ts:",
-        "    line 1, col 1: // ---",
-        "  b.ts:",
-        "    line 3, col 1: // ===",
+        "  a.ts:1:1: // ---",
+        "  b.ts:3:1: // ===",
       ]
     `);
   });
@@ -84,8 +60,7 @@ describe("buildBlockReason", () => {
   it("formats the full message", () => {
     expect(buildBlockReason([finding("src/x.ts", [node("// ----", 7)])])).toMatchInlineSnapshot(`
       "Write blocked — fence/divider comments in added code:
-        src/x.ts:
-          line 7, col 1: // ----
+        src/x.ts:7:1: // ----
       Remove these comments and retry."
     `);
   });
@@ -95,8 +70,7 @@ describe("buildWarnText", () => {
   it("formats the full message", () => {
     expect(buildWarnText([finding("src/y.ts", [node("// ===", 2)])])).toMatchInlineSnapshot(`
       "⚠ pi-fence: fence/divider comments detected in added code:
-        src/y.ts:
-          line 2, col 1: // ===
+        src/y.ts:2:1: // ===
       Please remove them."
     `);
   });
@@ -106,8 +80,7 @@ describe("buildRemoveText", () => {
   it("formats the full message", () => {
     expect(buildRemoveText([finding("src/z.ts", [node("// ***", 4)])])).toMatchInlineSnapshot(`
       "ℹ pi-fence: fence/divider comments were automatically removed:
-        src/z.ts:
-          line 4, col 1: // ***
+        src/z.ts:4:1: // ***
       Do not add them back."
     `);
   });
@@ -121,10 +94,9 @@ describe("buildRemoveText", () => {
     ).toMatchInlineSnapshot(`
       "ℹ pi-fence: fence/divider comments were automatically removed:
         a.ts:
-          line 1, col 1: // ---
-          line 3, col 1: // ===
-        b.ts:
-          line 10, col 1: // ###
+          1:1: // ---
+          3:1: // ===
+        b.ts:10:1: // ###
       Do not add them back."
     `);
   });

--- a/packages/pi-fence/src/tests/messages.test.ts
+++ b/packages/pi-fence/src/tests/messages.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBlockReason,
+  buildFindingLines,
+  buildRemoveText,
+  buildWarnText,
+  formatFinding,
+} from "../messages.js";
+import type { CommentNode } from "../parse.js";
+import type { Finding } from "../types.js";
+
+function node(text: string, startLine: number, startCol = 0): CommentNode {
+  return { text, startLine, startCol, endLine: startLine, endCol: startCol + text.length };
+}
+
+function finding(relativePath: string, fences: CommentNode[]): Finding {
+  return { relativePath, fences };
+}
+
+describe("formatFinding", () => {
+  it("formats line and col (1-indexed) with trimmed text", () => {
+    expect(formatFinding(node("// ---- section ----", 3, 0))).toMatchInlineSnapshot(
+      `"    line 3, col 1: // ---- section ----"`,
+    );
+  });
+
+  it("adjusts col to 1-indexed", () => {
+    expect(formatFinding(node("// ===", 10, 4))).toMatchInlineSnapshot(
+      `"    line 10, col 5: // ==="`,
+    );
+  });
+
+  it("trims surrounding whitespace from the comment text", () => {
+    expect(formatFinding(node("  // --- trim me ---  ", 1))).toMatchInlineSnapshot(
+      `"    line 1, col 1: // --- trim me ---"`,
+    );
+  });
+});
+
+describe("buildFindingLines", () => {
+  it("returns empty array for empty findings", () => {
+    expect(buildFindingLines([])).toMatchInlineSnapshot(`[]`);
+  });
+
+  it("formats a single file with one fence", () => {
+    expect(buildFindingLines([finding("src/foo.ts", [node("// ----", 2)])])).toMatchInlineSnapshot(`
+      [
+        "  src/foo.ts:",
+        "    line 2, col 1: // ----",
+      ]
+    `);
+  });
+
+  it("formats multiple fences in one file", () => {
+    expect(
+      buildFindingLines([finding("src/bar.ts", [node("// ====", 1), node("// ####", 5)])]),
+    ).toMatchInlineSnapshot(`
+      [
+        "  src/bar.ts:",
+        "    line 1, col 1: // ====",
+        "    line 5, col 1: // ####",
+      ]
+    `);
+  });
+
+  it("formats multiple files", () => {
+    expect(
+      buildFindingLines([
+        finding("a.ts", [node("// ---", 1)]),
+        finding("b.ts", [node("// ===", 3)]),
+      ]),
+    ).toMatchInlineSnapshot(`
+      [
+        "  a.ts:",
+        "    line 1, col 1: // ---",
+        "  b.ts:",
+        "    line 3, col 1: // ===",
+      ]
+    `);
+  });
+});
+
+describe("buildBlockReason", () => {
+  it("formats the full message", () => {
+    expect(buildBlockReason([finding("src/x.ts", [node("// ----", 7)])])).toMatchInlineSnapshot(`
+      "Write blocked — fence/divider comments in added code:
+        src/x.ts:
+          line 7, col 1: // ----
+      Remove these comments and retry."
+    `);
+  });
+});
+
+describe("buildWarnText", () => {
+  it("formats the full message", () => {
+    expect(buildWarnText([finding("src/y.ts", [node("// ===", 2)])])).toMatchInlineSnapshot(`
+      "⚠ pi-fence: fence/divider comments detected in added code:
+        src/y.ts:
+          line 2, col 1: // ===
+      Please remove them."
+    `);
+  });
+});
+
+describe("buildRemoveText", () => {
+  it("formats the full message", () => {
+    expect(buildRemoveText([finding("src/z.ts", [node("// ***", 4)])])).toMatchInlineSnapshot(`
+      "ℹ pi-fence: fence/divider comments were automatically removed:
+        src/z.ts:
+          line 4, col 1: // ***
+      Do not add them back."
+    `);
+  });
+
+  it("formats multiple files", () => {
+    expect(
+      buildRemoveText([
+        finding("a.ts", [node("// ---", 1), node("// ===", 3)]),
+        finding("b.ts", [node("// ###", 10)]),
+      ]),
+    ).toMatchInlineSnapshot(`
+      "ℹ pi-fence: fence/divider comments were automatically removed:
+        a.ts:
+          line 1, col 1: // ---
+          line 3, col 1: // ===
+        b.ts:
+          line 10, col 1: // ###
+      Do not add them back."
+    `);
+  });
+});

--- a/packages/pi-fence/src/tests/modes.test.ts
+++ b/packages/pi-fence/src/tests/modes.test.ts
@@ -1,9 +1,9 @@
 import {
-  createTestSession,
-  when,
   calls,
+  createTestSession,
   says,
   type TestSession,
+  when,
 } from "@marcfargas/pi-test-harness";
 import { afterEach, describe, expect, it } from "vitest";
 import piFence from "../index.js";
@@ -13,8 +13,7 @@ type FenceMode = "warn" | "block" | "remove";
 function fenceExtension(mode: FenceMode) {
   return (pi: any) => {
     const orig = pi.getFlag.bind(pi);
-    pi.getFlag = (name: string) =>
-      name === "pi-fence-mode" ? mode : orig(name);
+    pi.getFlag = (name: string) => (name === "pi-fence-mode" ? mode : orig(name));
     piFence(pi);
   };
 }
@@ -29,12 +28,7 @@ const CONTENT_WITH_FENCE = [
   "",
 ].join("\n");
 
-const CONTENT_CLEAN = [
-  "function greet() {",
-  '  return "hello";',
-  "}",
-  "",
-].join("\n");
+const CONTENT_CLEAN = ["function greet() {", '  return "hello";', "}", ""].join("\n");
 
 describe("pi-fence modes", { timeout: 30_000 }, () => {
   let t: TestSession;

--- a/packages/pi-fence/src/tests/modes.test.ts
+++ b/packages/pi-fence/src/tests/modes.test.ts
@@ -1,0 +1,208 @@
+import {
+  createTestSession,
+  when,
+  calls,
+  says,
+  type TestSession,
+} from "@marcfargas/pi-test-harness";
+import { afterEach, describe, expect, it } from "vitest";
+import piFence from "../index.js";
+
+type FenceMode = "warn" | "block" | "remove";
+
+function fenceExtension(mode: FenceMode) {
+  return (pi: any) => {
+    const orig = pi.getFlag.bind(pi);
+    pi.getFlag = (name: string) =>
+      name === "pi-fence-mode" ? mode : orig(name);
+    piFence(pi);
+  };
+}
+
+const FILE = "src/greet.ts";
+
+const CONTENT_WITH_FENCE = [
+  "function greet() {",
+  "// ---- helpers ----",
+  '  return "hello";',
+  "}",
+  "",
+].join("\n");
+
+const CONTENT_CLEAN = [
+  "function greet() {",
+  '  return "hello";',
+  "}",
+  "",
+].join("\n");
+
+describe("pi-fence modes", { timeout: 30_000 }, () => {
+  let t: TestSession;
+  afterEach(() => t?.dispose());
+
+  describe("warn mode", () => {
+    it("appends warning to tool result when fence is detected in write", async () => {
+      t = await createTestSession({
+        extensionFactories: [fenceExtension("warn")],
+        mockTools: { write: "Written." },
+      });
+
+      await t.run(
+        when("Write a file", [
+          calls("write", { path: FILE, content: CONTENT_WITH_FENCE }),
+          says("Done."),
+        ]),
+      );
+
+      const [result] = t.events.toolResultsFor("write");
+      expect(result.text).toContain("⚠ pi-fence: fence/divider comments detected in added code:");
+      expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
+      expect(t.events.blockedCalls()).toHaveLength(0);
+    });
+
+    it("appends warning to tool result when fence is added via edit", async () => {
+      t = await createTestSession({
+        extensionFactories: [fenceExtension("warn")],
+        mockTools: { edit: "Edited." },
+      });
+
+      await t.run(
+        when("Edit a file", [
+          calls("edit", {
+            path: FILE,
+            edits: [{ oldText: CONTENT_CLEAN, newText: CONTENT_WITH_FENCE }],
+          }),
+          says("Done."),
+        ]),
+      );
+
+      const [result] = t.events.toolResultsFor("edit");
+      expect(result.text).toContain("⚠ pi-fence: fence/divider comments detected in added code:");
+      expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
+      expect(t.events.blockedCalls()).toHaveLength(0);
+    });
+
+    it("passes through cleanly when no fences are present", async () => {
+      t = await createTestSession({
+        extensionFactories: [fenceExtension("warn")],
+        mockTools: { write: "Written." },
+      });
+
+      await t.run(
+        when("Write a file", [
+          calls("write", { path: FILE, content: CONTENT_CLEAN }),
+          says("Done."),
+        ]),
+      );
+
+      const [result] = t.events.toolResultsFor("write");
+      expect(result.text).not.toContain("pi-fence");
+      expect(t.events.blockedCalls()).toHaveLength(0);
+    });
+  });
+
+  describe("block mode", () => {
+    it("blocks write containing a fence comment", async () => {
+      t = await createTestSession({
+        extensionFactories: [fenceExtension("block")],
+        mockTools: { write: "Written." },
+        propagateErrors: false,
+      });
+
+      await t.run(
+        when("Write a file", [
+          calls("write", { path: FILE, content: CONTENT_WITH_FENCE }),
+          says("I'll remove the fence comments."),
+        ]),
+      );
+
+      const [blocked] = t.events.blockedCalls();
+      expect(blocked.toolName).toBe("write");
+      expect(blocked.blockReason).toContain(
+        "Write blocked — fence/divider comments in added code:",
+      );
+      expect(blocked.blockReason).toContain("src/greet.ts:2:1: // ---- helpers ----");
+    });
+
+    it("allows clean write through without blocking", async () => {
+      t = await createTestSession({
+        extensionFactories: [fenceExtension("block")],
+        mockTools: { write: "Written." },
+      });
+
+      await t.run(
+        when("Write a file", [
+          calls("write", { path: FILE, content: CONTENT_CLEAN }),
+          says("Done."),
+        ]),
+      );
+
+      expect(t.events.blockedCalls()).toHaveLength(0);
+      expect(t.events.toolResultsFor("write")).toHaveLength(1);
+    });
+  });
+
+  describe("remove mode", () => {
+    it("strips fence comments from write content and appends removal notice", async () => {
+      let capturedContent = "";
+
+      t = await createTestSession({
+        extensionFactories: [fenceExtension("remove")],
+        mockTools: {
+          write: (params) => {
+            capturedContent = params.content as string;
+            return "Written.";
+          },
+        },
+      });
+
+      await t.run(
+        when("Write a file", [
+          calls("write", { path: FILE, content: CONTENT_WITH_FENCE }),
+          says("Done."),
+        ]),
+      );
+
+      expect(capturedContent).not.toContain("// ---- helpers ----");
+      const [result] = t.events.toolResultsFor("write");
+      expect(result.text).toContain(
+        "ℹ pi-fence: fence/divider comments were automatically removed:",
+      );
+      expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
+      expect(t.events.blockedCalls()).toHaveLength(0);
+    });
+
+    it("strips fence comments from edit newText and appends removal notice", async () => {
+      let capturedNewText = "";
+
+      t = await createTestSession({
+        extensionFactories: [fenceExtension("remove")],
+        mockTools: {
+          edit: (params) => {
+            const edits = params.edits as Array<{ oldText: string; newText: string }>;
+            capturedNewText = edits[0].newText;
+            return "Edited.";
+          },
+        },
+      });
+
+      await t.run(
+        when("Edit a file", [
+          calls("edit", {
+            path: FILE,
+            edits: [{ oldText: CONTENT_CLEAN, newText: CONTENT_WITH_FENCE }],
+          }),
+          says("Done."),
+        ]),
+      );
+
+      expect(capturedNewText).not.toContain("// ---- helpers ----");
+      const [result] = t.events.toolResultsFor("edit");
+      expect(result.text).toContain(
+        "ℹ pi-fence: fence/divider comments were automatically removed:",
+      );
+      expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
+      expect(t.events.blockedCalls()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/pi-fence/src/types.ts
+++ b/packages/pi-fence/src/types.ts
@@ -1,0 +1,6 @@
+import type { CommentNode } from "./parse.js";
+
+export interface Finding {
+  relativePath: string;
+  fences: CommentNode[];
+}


### PR DESCRIPTION
## What

Extract message builders, compact finding format, integration tests for all 3 modes.

## Changes

### `src/messages.ts` (new)
- `buildFindingLines`, `buildBlockReason`, `buildWarnText`, `buildRemoveText` extracted from `index.ts`
- Single-fence finding inline: `src/foo.ts:2:1: // ---- helpers ----`
- Multi-fence finding indented under filename
- Format: `line:col` not `line N, col M` (matches compiler convention)
- `formatFinding` local to `buildFindingLines`, not exported

### `src/index.ts`
- Import builders from `./messages.js`
- Remove mode appends `ℹ pi-fence` notice so agent sees what was stripped

### `src/tests/messages.test.ts` (new)
Unit tests: `buildFindingLines`, `buildBlockReason`, `buildWarnText`, `buildRemoveText`.

### `src/tests/modes.test.ts` (new)
Integration tests via `createTestSession` + playbook DSL. LLM mocked. Cover:
- **warn** — write/edit with fence → warning appended to result
- **warn** — clean write → no warning
- **block** — write with fence → call blocked, reason has file:line:col
- **block** — clean write → passes through
- **remove** — write/edit with fence → fences stripped from content, removal notice appended