### PR TITLE
feat(pi-fence): add UI notifications with fence count in warn/remove modes

### DIFF
--- a/packages/pi-fence/README.md
+++ b/packages/pi-fence/README.md
@@ -77,5 +77,7 @@ pnpm check
 To test changes manually, pass the source entry point directly to pi with the `-e` flag:
 
 ```bash
-pi -e src/index.ts
+pi -ne -e src/index.ts
+pi -ne -e src/index.ts --pi-fence-mode block
+pi -ne -e src/index.ts --pi-fence-mode remove
 ```

--- a/packages/pi-fence/README.md
+++ b/packages/pi-fence/README.md
@@ -73,3 +73,9 @@ pnpm test
 pnpm typecheck
 pnpm check
 ```
+
+To test changes manually, pass the source entry point directly to pi with the `-e` flag:
+
+```bash
+pi -e src/index.ts
+```

--- a/packages/pi-fence/src/index.test.ts
+++ b/packages/pi-fence/src/index.test.ts
@@ -56,6 +56,10 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
       expect(result.text).toContain("⚠ pi-fence: fence/divider comments detected in added code:");
       expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
       expect(t.events.blockedCalls()).toHaveLength(0);
+
+      const [notification] = t.events.uiCallsFor("notify");
+      expect(notification.args[0]).toBe("pi-fence: model tried to insert 1 fence comment");
+      expect(notification.args[1]).toBe("warning");
     });
 
     it("appends warning to tool result when fence is added via edit", async () => {
@@ -78,6 +82,10 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
       expect(result.text).toContain("⚠ pi-fence: fence/divider comments detected in added code:");
       expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
       expect(t.events.blockedCalls()).toHaveLength(0);
+
+      const [notification] = t.events.uiCallsFor("notify");
+      expect(notification.args[0]).toBe("pi-fence: model tried to insert 1 fence comment");
+      expect(notification.args[1]).toBe("warning");
     });
 
     it("passes through cleanly when no fences are present", async () => {
@@ -96,6 +104,7 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
       const [result] = t.events.toolResultsFor("write");
       expect(result.text).not.toContain("pi-fence");
       expect(t.events.blockedCalls()).toHaveLength(0);
+      expect(t.events.uiCallsFor("notify")).toHaveLength(0);
     });
   });
 
@@ -168,6 +177,10 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
       );
       expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
       expect(t.events.blockedCalls()).toHaveLength(0);
+
+      const [notification] = t.events.uiCallsFor("notify");
+      expect(notification.args[0]).toBe("pi-fence: 1 fence comment were auto-removed");
+      expect(notification.args[1]).toBe("info");
     });
 
     it("strips fence comments from edit newText and appends removal notice", async () => {
@@ -201,6 +214,10 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
       );
       expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
       expect(t.events.blockedCalls()).toHaveLength(0);
+
+      const [notification] = t.events.uiCallsFor("notify");
+      expect(notification.args[0]).toBe("pi-fence: 1 fence comment were auto-removed");
+      expect(notification.args[1]).toBe("info");
     });
   });
 

--- a/packages/pi-fence/src/index.test.ts
+++ b/packages/pi-fence/src/index.test.ts
@@ -53,13 +53,13 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
       );
 
       const [result] = t.events.toolResultsFor("write");
-      expect(result.text).toContain("⚠ pi-fence: fence/divider comments detected in added code:");
-      expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
+      expect(result.text).toContain("Fence comments detected in added code:");
+      expect(result.text).toContain("src/greet.ts:2: // ---- helpers ----");
       expect(t.events.blockedCalls()).toHaveLength(0);
 
       const [notification] = t.events.uiCallsFor("notify");
-      expect(notification.args[0]).toBe("pi-fence: model tried to insert 1 fence comment");
-      expect(notification.args[1]).toBe("warning");
+      expect(notification.args[0]).toBe("Detected 1 fence comment, agent asked to remove.");
+      expect(notification.args[1]).toBe("info");
     });
 
     it("appends warning to tool result when fence is added via edit", async () => {
@@ -79,13 +79,13 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
       );
 
       const [result] = t.events.toolResultsFor("edit");
-      expect(result.text).toContain("⚠ pi-fence: fence/divider comments detected in added code:");
-      expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
+      expect(result.text).toContain("Fence comments detected in added code:");
+      expect(result.text).toContain("src/greet.ts:2: // ---- helpers ----");
       expect(t.events.blockedCalls()).toHaveLength(0);
 
       const [notification] = t.events.uiCallsFor("notify");
-      expect(notification.args[0]).toBe("pi-fence: model tried to insert 1 fence comment");
-      expect(notification.args[1]).toBe("warning");
+      expect(notification.args[0]).toBe("Detected 1 fence comment, agent asked to remove.");
+      expect(notification.args[1]).toBe("info");
     });
 
     it("passes through cleanly when no fences are present", async () => {
@@ -125,10 +125,8 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
 
       const [blocked] = t.events.blockedCalls();
       expect(blocked.toolName).toBe("write");
-      expect(blocked.blockReason).toContain(
-        "Write blocked — fence/divider comments in added code:",
-      );
-      expect(blocked.blockReason).toContain("src/greet.ts:2:1: // ---- helpers ----");
+      expect(blocked.blockReason).toContain("Write blocked — fence comments in added code:");
+      expect(blocked.blockReason).toContain("src/greet.ts:2: // ---- helpers ----");
     });
 
     it("allows clean write through without blocking", async () => {
@@ -172,14 +170,12 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
 
       expect(capturedContent).not.toContain("// ---- helpers ----");
       const [result] = t.events.toolResultsFor("write");
-      expect(result.text).toContain(
-        "ℹ pi-fence: fence/divider comments were automatically removed:",
-      );
-      expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
+      expect(result.text).toContain("Fence comments were automatically removed:");
+      expect(result.text).toContain("src/greet.ts:2: // ---- helpers ----");
       expect(t.events.blockedCalls()).toHaveLength(0);
 
       const [notification] = t.events.uiCallsFor("notify");
-      expect(notification.args[0]).toBe("pi-fence: 1 fence comment were auto-removed");
+      expect(notification.args[0]).toBe("Removed 1 fence comment, agent notified.");
       expect(notification.args[1]).toBe("info");
     });
 
@@ -209,14 +205,12 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
 
       expect(capturedNewText).not.toContain("// ---- helpers ----");
       const [result] = t.events.toolResultsFor("edit");
-      expect(result.text).toContain(
-        "ℹ pi-fence: fence/divider comments were automatically removed:",
-      );
-      expect(result.text).toContain("src/greet.ts:2:1: // ---- helpers ----");
+      expect(result.text).toContain("Fence comments were automatically removed:");
+      expect(result.text).toContain("src/greet.ts:2: // ---- helpers ----");
       expect(t.events.blockedCalls()).toHaveLength(0);
 
       const [notification] = t.events.uiCallsFor("notify");
-      expect(notification.args[0]).toBe("pi-fence: 1 fence comment were auto-removed");
+      expect(notification.args[0]).toBe("Removed 1 fence comment, agent notified.");
       expect(notification.args[1]).toBe("info");
     });
   });
@@ -274,7 +268,7 @@ describe("pi-fence modes", { timeout: 30_000 }, () => {
 
       expect(t.events.blockedCalls()).toHaveLength(0);
       const [result] = t.events.toolResultsFor("write");
-      expect(result.text).toContain("⚠ pi-fence");
+      expect(result.text).toContain("Fence comments detected in added code:");
     });
   });
 });

--- a/packages/pi-fence/src/index.ts
+++ b/packages/pi-fence/src/index.ts
@@ -13,12 +13,12 @@ import { getMode } from "./mode.js";
 import type { CommentNode, FencesFinding } from "./types.js";
 
 const PROMPT_INSTRUCTIONS = `
-Do not insert decorative fence or divider comments like:
+Do not insert decorative fence comments like:
   // ---- section ----
   // ===== Title =====
   // *** helpers ***
   # ################
-Use named functions, classes, or blank lines to separate code sections instead.
+Code-smell, if needed, extract to function or file instead. 
 `.trim();
 
 export default function piFence(pi: ExtensionAPI) {
@@ -136,7 +136,7 @@ export default function piFence(pi: ExtensionAPI) {
       case "remove": {
         const n = finding.fences.length;
         ctx.ui.notify(
-          `pi-fence: ${n} fence ${n === 1 ? "comment" : "comments"} were auto-removed`,
+          `Removed ${n} fence ${n === 1 ? "comment" : "comments"}, agent notified.`,
           "info",
         );
         return { content: [...event.content, { type: "text", text: buildRemoveText([finding]) }] };
@@ -144,8 +144,8 @@ export default function piFence(pi: ExtensionAPI) {
       case "warn": {
         const n = finding.fences.length;
         ctx.ui.notify(
-          `pi-fence: model tried to insert ${n} fence ${n === 1 ? "comment" : "comments"}`,
-          "warning",
+          `Detected ${n} fence ${n === 1 ? "comment" : "comments"}, agent asked to remove.`,
+          "info",
         );
         return { content: [...event.content, { type: "text", text: buildWarnText([finding]) }] };
       }

--- a/packages/pi-fence/src/index.ts
+++ b/packages/pi-fence/src/index.ts
@@ -117,7 +117,7 @@ export default function piFence(pi: ExtensionAPI) {
     }
   });
 
-  pi.on("tool_result", async (event) => {
+  pi.on("tool_result", async (event, ctx) => {
     if (!isWriteToolResult(event) && !isEditToolResult(event)) {
       return undefined;
     }
@@ -133,10 +133,16 @@ export default function piFence(pi: ExtensionAPI) {
     // inline, alongside the write confirmation, without a separate turn.
     const mode = getMode(pi);
     switch (mode) {
-      case "remove":
+      case "remove": {
+        const n = finding.fences.length;
+        ctx.ui.notify(`pi-fence: ${n} fence ${n === 1 ? "comment" : "comments"} were auto-removed`, "info");
         return { content: [...event.content, { type: "text", text: buildRemoveText([finding]) }] };
-      case "warn":
+      }
+      case "warn": {
+        const n = finding.fences.length;
+        ctx.ui.notify(`pi-fence: model tried to insert ${n} fence ${n === 1 ? "comment" : "comments"}`, "warning");
         return { content: [...event.content, { type: "text", text: buildWarnText([finding]) }] };
+      }
       case "block":
         return undefined;
     }

--- a/packages/pi-fence/src/index.ts
+++ b/packages/pi-fence/src/index.ts
@@ -135,12 +135,18 @@ export default function piFence(pi: ExtensionAPI) {
     switch (mode) {
       case "remove": {
         const n = finding.fences.length;
-        ctx.ui.notify(`pi-fence: ${n} fence ${n === 1 ? "comment" : "comments"} were auto-removed`, "info");
+        ctx.ui.notify(
+          `pi-fence: ${n} fence ${n === 1 ? "comment" : "comments"} were auto-removed`,
+          "info",
+        );
         return { content: [...event.content, { type: "text", text: buildRemoveText([finding]) }] };
       }
       case "warn": {
         const n = finding.fences.length;
-        ctx.ui.notify(`pi-fence: model tried to insert ${n} fence ${n === 1 ? "comment" : "comments"}`, "warning");
+        ctx.ui.notify(
+          `pi-fence: model tried to insert ${n} fence ${n === 1 ? "comment" : "comments"}`,
+          "warning",
+        );
         return { content: [...event.content, { type: "text", text: buildWarnText([finding]) }] };
       }
       case "block":

--- a/packages/pi-fence/src/messages.test.ts
+++ b/packages/pi-fence/src/messages.test.ts
@@ -18,7 +18,7 @@ describe("buildFindingLines", () => {
   it("formats a single file with one fence", () => {
     expect(buildFindingLines([finding("src/foo.ts", [node("// ----", 1)])])).toMatchInlineSnapshot(`
       [
-        "  src/foo.ts:2:1: // ----",
+        "  src/foo.ts:2: // ----",
       ]
     `);
   });
@@ -29,8 +29,8 @@ describe("buildFindingLines", () => {
     ).toMatchInlineSnapshot(`
       [
         "  src/bar.ts:",
-        "    1:1: // ====",
-        "    5:1: // ####",
+        "    1: // ====",
+        "    5: // ####",
       ]
     `);
   });
@@ -43,8 +43,8 @@ describe("buildFindingLines", () => {
       ]),
     ).toMatchInlineSnapshot(`
       [
-        "  a.ts:1:1: // ---",
-        "  b.ts:3:1: // ===",
+        "  a.ts:1: // ---",
+        "  b.ts:3: // ===",
       ]
     `);
   });
@@ -53,8 +53,8 @@ describe("buildFindingLines", () => {
 describe("buildBlockReason", () => {
   it("formats the full message", () => {
     expect(buildBlockReason([finding("src/x.ts", [node("// ----", 6)])])).toMatchInlineSnapshot(`
-      "Write blocked — fence/divider comments in added code:
-        src/x.ts:7:1: // ----
+      "Write blocked — fence comments in added code:
+        src/x.ts:7: // ----
       Remove these comments and retry."
     `);
   });
@@ -63,8 +63,8 @@ describe("buildBlockReason", () => {
 describe("buildWarnText", () => {
   it("formats the full message", () => {
     expect(buildWarnText([finding("src/y.ts", [node("// ===", 1)])])).toMatchInlineSnapshot(`
-      "⚠ pi-fence: fence/divider comments detected in added code:
-        src/y.ts:2:1: // ===
+      "Fence comments detected in added code:
+        src/y.ts:2: // ===
       Please remove them."
     `);
   });
@@ -73,8 +73,8 @@ describe("buildWarnText", () => {
 describe("buildRemoveText", () => {
   it("formats the full message", () => {
     expect(buildRemoveText([finding("src/z.ts", [node("// ***", 3)])])).toMatchInlineSnapshot(`
-      "ℹ pi-fence: fence/divider comments were automatically removed:
-        src/z.ts:4:1: // ***
+      "Fence comments were automatically removed:
+        src/z.ts:4: // ***
       Do not add them back."
     `);
   });
@@ -86,11 +86,11 @@ describe("buildRemoveText", () => {
         finding("b.ts", [node("// ###", 9)]),
       ]),
     ).toMatchInlineSnapshot(`
-      "ℹ pi-fence: fence/divider comments were automatically removed:
+      "Fence comments were automatically removed:
         a.ts:
-          1:1: // ---
-          3:1: // ===
-        b.ts:10:1: // ###
+          1: // ---
+          3: // ===
+        b.ts:10: // ###
       Do not add them back."
     `);
   });

--- a/packages/pi-fence/src/messages.ts
+++ b/packages/pi-fence/src/messages.ts
@@ -1,8 +1,8 @@
 import type { CommentNode, FencesFinding } from "./types.js";
 
 export function buildFindingLines(findings: FencesFinding[]): string[] {
-  function formatFinding({ startLine, startCol, text }: CommentNode): string {
-    return `${startLine + 1}:${startCol + 1}: ${text.trimEnd()}`;
+  function formatFinding({ startLine, text }: CommentNode): string {
+    return `${startLine + 1}: ${text.trimEnd()}`;
   }
 
   const lines: string[] = [];
@@ -19,7 +19,7 @@ export function buildFindingLines(findings: FencesFinding[]): string[] {
 
 export function buildBlockReason(findings: FencesFinding[]): string {
   return [
-    "Write blocked — fence/divider comments in added code:",
+    "Write blocked — fence comments in added code:",
     ...buildFindingLines(findings),
     "Remove these comments and retry.",
   ].join("\n");
@@ -27,7 +27,7 @@ export function buildBlockReason(findings: FencesFinding[]): string {
 
 export function buildWarnText(findings: FencesFinding[]): string {
   return [
-    "⚠ pi-fence: fence/divider comments detected in added code:",
+    "Fence comments detected in added code:",
     ...buildFindingLines(findings),
     "Please remove them.",
   ].join("\n");
@@ -35,7 +35,7 @@ export function buildWarnText(findings: FencesFinding[]): string {
 
 export function buildRemoveText(findings: FencesFinding[]): string {
   return [
-    "ℹ pi-fence: fence/divider comments were automatically removed:",
+    "Fence comments were automatically removed:",
     ...buildFindingLines(findings),
     "Do not add them back.",
   ].join("\n");

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,9 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
## Summary

Adds non-blocking toast notifications via `ctx.ui.notify()` so the user sees what's happening in the TUI, not just the model.

### warn mode
Shows a **warning** notification when the model tries to insert fence/divider comments:
> `pi-fence: model tried to insert 2 fence comments`

### remove mode
Shows an **info** notification when comments are silently stripped:
> `pi-fence: 2 fence comments were auto-removed`

Both messages include the exact count with correct singular/plural (`1 fence comment` vs `N fence comments`).

## Changes
- `packages/pi-fence/src/index.ts` — add `ctx` to `tool_result` handler, call `ctx.ui.notify()` in `warn` and `remove` cases
- `packages/pi-fence/src/index.test.ts` — assert notification method, message, and severity in all relevant test cases