### PR TITLE
perf(pi-fence): regex pre-check before tree-sitter parse

### DIFF
--- a/packages/pi-fence/src/fence.test.ts
+++ b/packages/pi-fence/src/fence.test.ts
@@ -1,11 +1,64 @@
 import { describe, expect, it } from "vitest";
-import { isFenceComment, removeFenceComments, stripMarkers } from "./fence.js";
+import { hasFenceCandidate, isFenceComment, removeFenceComments, stripMarkers } from "./fence.js";
 import type { CommentNode } from "./types.js";
 
 // Helper: build a minimal CommentNode from a single-line comment string.
 function node(text: string, startLine: number, startCol = 0): CommentNode {
   return { text, startLine, startCol, endLine: startLine, endCol: startCol + text.length };
 }
+
+describe("hasFenceCandidate", () => {
+  it("returns false for empty string", () => {
+    expect(hasFenceCandidate("")).toBe(false);
+  });
+
+  it("returns false for plain prose", () => {
+    expect(hasFenceCandidate("const x = hello + world;")).toBe(false);
+  });
+
+  it("returns false for single-dash words", () => {
+    expect(hasFenceCandidate("some-value or off-by-one")).toBe(false);
+  });
+
+  it("returns false for a URL with hyphens", () => {
+    expect(hasFenceCandidate("// https://example.com/some-path")).toBe(false);
+  });
+
+  it("returns false for two consecutive separator chars (below threshold)", () => {
+    expect(hasFenceCandidate("// ==")).toBe(false);
+  });
+
+  it("returns true for a line with a fence sequence", () => {
+    expect(hasFenceCandidate("// ---- section ----")).toBe(true);
+  });
+
+  it("returns true for === alone", () => {
+    expect(hasFenceCandidate("===")).toBe(true);
+  });
+
+  it("returns true for hash fence", () => {
+    expect(hasFenceCandidate("# ################")).toBe(true);
+  });
+
+  it("returns true for Unicode box-drawing sequence", () => {
+    expect(hasFenceCandidate("// ─────────────────────")).toBe(true);
+  });
+
+  it("returns true when fence sequence is buried in a large file", () => {
+    const content = "const a = 1;\nconst b = 2;\n// ---- helpers ----\nconst c = 3;\n";
+    expect(hasFenceCandidate(content)).toBe(true);
+  });
+
+  it("returns false for a large file with no fence sequences", () => {
+    const content = "const a = 1;\n// TODO: fix\nconst b = 2;\n".repeat(100);
+    expect(hasFenceCandidate(content)).toBe(false);
+  });
+
+  it("returns true even when fence sequence is inside a string literal (over-approximation)", () => {
+    // The full parser would correctly reject this; hasFenceCandidate is intentionally conservative.
+    expect(hasFenceCandidate('const s = "---- not a comment ----";')).toBe(true);
+  });
+});
 
 describe("stripMarkers", () => {
   it("strips // prefix", () => {

--- a/packages/pi-fence/src/fence.ts
+++ b/packages/pi-fence/src/fence.ts
@@ -53,6 +53,17 @@ export function stripMarkers(raw: string): string {
 }
 
 /**
+ * Fast pre-check: returns true when `text` contains any sequence of 3+
+ * separator characters, meaning it *could* contain a fence comment.
+ * Apply this directly to raw (un-stripped) text before running tree-sitter.
+ * A false return guarantees no fence comments exist; a true return requires
+ * the full parser pass to confirm.
+ */
+export function hasFenceCandidate(text: string): boolean {
+  return FENCE_SEQUENCE_RE.test(text);
+}
+
+/**
  * Returns true if the raw comment text is a decorative fence/divider comment.
  * The rawText should be the full text of the comment node as returned by tree-sitter
  * (including comment markers like `//`, `#`, `/* ... * /`).

--- a/packages/pi-fence/src/index.ts
+++ b/packages/pi-fence/src/index.ts
@@ -7,7 +7,7 @@ import {
   isWriteToolResult,
 } from "@earendil-works/pi-coding-agent";
 import { applyEdits } from "./edit.js";
-import { getFenceComments, removeFenceComments } from "./fence.js";
+import { getFenceComments, hasFenceCandidate, removeFenceComments } from "./fence.js";
 import { getLanguageDefinition } from "./languages/index.js";
 import { buildBlockReason, buildRemoveText, buildWarnText } from "./messages.js";
 import { getMode } from "./mode.js";
@@ -48,7 +48,7 @@ export default function piFence(pi: ExtensionAPI) {
     if (isToolCallEventType("write", event)) {
       const { path, content: newContent } = event.input;
       const def = getLanguageDefinition(path);
-      if (!def) {
+      if (!def || !hasFenceCandidate(newContent)) {
         return undefined;
       }
       const fences = await getFenceComments(newContent, def, signal);
@@ -71,7 +71,7 @@ export default function piFence(pi: ExtensionAPI) {
     if (isToolCallEventType("edit", event)) {
       const { path, edits } = event.input;
       const def = getLanguageDefinition(path);
-      if (!def) {
+      if (!def || !edits.some((e) => hasFenceCandidate(e.newText))) {
         return undefined;
       }
 
@@ -118,7 +118,9 @@ export default function piFence(pi: ExtensionAPI) {
           if (signal?.aborted) {
             return undefined;
           }
-          perEditFences[i] = await getFenceComments(edits[i].newText, def, signal);
+          if (hasFenceCandidate(edits[i].newText)) {
+            perEditFences[i] = await getFenceComments(edits[i].newText, def, signal);
+          }
         }
       }
 


### PR DESCRIPTION
## What

Add `hasFenceCandidate(text)` — runs `FENCE_SEQUENCE_RE` on raw content before touching tree-sitter.

## Why

Most writes have zero fence chars. Skip WASM parser entirely on miss.

## How

- `fence.ts`: export `hasFenceCandidate` (raw regex, no marker strip)
- `index.ts`: 3 guard points — write path, edit path (before `readExisting`+`applyEdits`), per-edit fallback
- `fence.test.ts`: 11 new unit tests

False return = no fences guaranteed (strip only removes chars, never adds). True = proceed to full parse.