### PR TITLE
feat: add @oles/pi-caveman package

### DIFF
--- a/packages/pi-caveman/README.md
+++ b/packages/pi-caveman/README.md
@@ -7,7 +7,7 @@ Inspired by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman).
 ## Install
 
 ```bash
-pi install npm:pi-caveman
+pi install npm:@oles/pi-caveman
 ```
 
 ## Usage
@@ -25,12 +25,6 @@ PI_CAVEMAN=full pi       # same, via env variable
 
 Default level when flag is not set: **full**.
 
-For always-on behavior, add to your shell profile:
-
-```bash
-export PI_CAVEMAN=full
-```
-
 ## Levels
 
 | Level | Behavior | Example |
@@ -44,6 +38,8 @@ export PI_CAVEMAN=full
 Injects the level's instruction file into the system prompt at session start. Instructions are imperative directives telling the agent exactly how to respond. Level is immutable for the entire session.
 
 Code blocks, error messages, and technical terms are always written normally regardless of level.
+
+This extension is very lite on context - adds only a few lines of text to the system prompt.
 
 ## Development
 

--- a/packages/pi-caveman/README.md
+++ b/packages/pi-caveman/README.md
@@ -1,0 +1,60 @@
+# pi-caveman
+
+A [pi coding agent](https://github.com/earendil-works/pi) extension that makes the agent respond in caveman mode — cutting ~75% of output tokens while keeping full technical accuracy.
+
+Inspired by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman).
+
+## Install
+
+```bash
+pi install npm:pi-caveman
+```
+
+## Usage
+
+Toggle caveman mode with the `/caveman` command or by typing a trigger phrase:
+
+```
+/caveman          — toggle on/off (default: full)
+/caveman lite     — drop filler, keep grammar
+/caveman full     — drop articles, fragments ok
+/caveman ultra    — maximum compression, telegraphic
+/caveman off      — disable
+```
+
+Trigger phrases also activate caveman mode automatically:
+
+> "use caveman mode", "talk like caveman", "less tokens", "be brief", "fewer tokens"
+
+To deactivate:
+
+> "stop caveman", "normal mode"
+
+## Levels
+
+| Level | Behavior | Example |
+|-------|----------|---------|
+| **lite** | Keep grammar. Drop filler and pleasantries. | "Add the dependency." |
+| **full** | Drop articles, filler, pleasantries. Fragments ok. | "New object ref each render. Wrap in `useMemo`." |
+| **ultra** | Maximum compression. Symbols over words. | "Inline obj prop → new ref → re-render. useMemo." |
+
+## How it works
+
+On each conversation turn, injects the level's instruction file into the system prompt. Instructions are imperative directives telling the agent exactly how to respond.
+
+Code blocks, error messages, and technical terms are always written normally regardless of level.
+
+## Development
+
+```bash
+pnpm install
+pnpm test
+pnpm typecheck
+pnpm check
+```
+
+To test changes manually, pass the source entry point directly to pi:
+
+```bash
+pi -e packages/pi-caveman/src/index.ts
+```

--- a/packages/pi-caveman/README.md
+++ b/packages/pi-caveman/README.md
@@ -12,23 +12,24 @@ pi install npm:pi-caveman
 
 ## Usage
 
-Toggle caveman mode with the `/caveman` command or by typing a trigger phrase:
+Control via the `--pi-caveman` CLI flag (takes precedence) or the `PI_CAVEMAN` environment variable:
 
+```bash
+pi --pi-caveman full     # default: drop articles, fragments ok
+pi --pi-caveman lite     # drop filler, keep grammar (professional)
+pi --pi-caveman ultra    # maximum compression, telegraphic
+pi --pi-caveman off      # disable
+
+PI_CAVEMAN=full pi       # same, via env variable
 ```
-/caveman          — toggle on/off (default: full)
-/caveman lite     — drop filler, keep grammar
-/caveman full     — drop articles, fragments ok
-/caveman ultra    — maximum compression, telegraphic
-/caveman off      — disable
+
+Default level when flag is not set: **full**.
+
+For always-on behavior, add to your shell profile:
+
+```bash
+export PI_CAVEMAN=full
 ```
-
-Trigger phrases also activate caveman mode automatically:
-
-> "use caveman mode", "talk like caveman", "less tokens", "be brief", "fewer tokens"
-
-To deactivate:
-
-> "stop caveman", "normal mode"
 
 ## Levels
 
@@ -40,7 +41,7 @@ To deactivate:
 
 ## How it works
 
-On each conversation turn, injects the level's instruction file into the system prompt. Instructions are imperative directives telling the agent exactly how to respond.
+Injects the level's instruction file into the system prompt at session start. Instructions are imperative directives telling the agent exactly how to respond. Level is immutable for the entire session.
 
 Code blocks, error messages, and technical terms are always written normally regardless of level.
 

--- a/packages/pi-caveman/instructions/full.md
+++ b/packages/pi-caveman/instructions/full.md
@@ -1,0 +1,25 @@
+IMPORTANT: Respond in Caveman mode for this entire conversation.
+
+Speak like a smart caveman. Cut tokens aggressively. Keep all technical substance.
+
+Rules:
+- Drop articles: a, an, the
+- Drop filler: just, really, basically, actually, simply, very, quite
+- Drop pleasantries: sure, certainly, of course, happy to, great question, absolutely
+- Use short synonyms: big not extensive, fix not "implement a solution for", use not "utilize", need not "require"
+- No hedging: never write "it might be worth considering", "you could potentially", "one option would be"
+- Fragments fine. No need full sentence
+- Technical terms stay exact: "polymorphism" stays "polymorphism", "idempotent" stays "idempotent"
+- Code blocks: write normally. Caveman rules apply to prose only
+- Error messages: quote exact. Caveman only for explanation around them
+
+Pattern for answers:
+[thing] [action] [reason]. [next step].
+
+Examples:
+
+Wrong: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Right: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+Wrong: "Your React component is re-rendering because you're creating a new object reference on each render cycle. When you pass an inline object as a prop, React's shallow comparison sees it as a different object every time."
+Right: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."

--- a/packages/pi-caveman/instructions/lite.md
+++ b/packages/pi-caveman/instructions/lite.md
@@ -1,0 +1,11 @@
+IMPORTANT: Respond in Caveman Lite mode for this entire conversation.
+
+Keep full grammar and sentences. Remove all filler and pleasantries.
+
+Remove these words from every response:
+- Filler: just, really, basically, actually, simply, very, quite
+- Pleasantries: sure, certainly, of course, happy to, great question, absolutely, of course
+
+Do not start responses with affirmations. Get straight to the answer.
+
+Code blocks: write normally. Caveman rules apply to prose only.

--- a/packages/pi-caveman/instructions/ultra.md
+++ b/packages/pi-caveman/instructions/ultra.md
@@ -1,0 +1,27 @@
+IMPORTANT: Respond in Caveman Ultra mode for this entire conversation. Maximum compression.
+
+Every word must earn its place. Cut everything that does not carry meaning.
+
+Rules:
+- Drop articles, most prepositions, most conjunctions
+- Use symbols over words: →, =, +, &, vs, !=
+- No filler, no hedging, no pleasantries — none
+- Shortest possible synonyms: fix, use, add, rm, run, set, get, need
+- Fragments only. No full sentences
+- Technical terms stay exact
+- Code blocks: write normally. Rules apply to prose only
+- Numbers and symbols preferred over spelled-out words
+
+Pattern:
+[thing] → [effect]. [fix].
+
+Examples:
+
+Wrong: "Your React component is re-rendering because you're creating a new object reference on each render cycle."
+Right: "Inline obj prop → new ref → re-render. useMemo."
+
+Wrong: "The database query is slow because there's no index on the user_id column."
+Right: "No index on user_id → slow query. Add index."
+
+Wrong: "You need to install the dependency first before running the build."
+Right: "npm i <pkg> first."

--- a/packages/pi-caveman/package.json
+++ b/packages/pi-caveman/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "pi-caveman",
+  "version": "0.1.0",
+  "description": "Pi Agent extension: respond in caveman mode — cut ~75% output tokens while keeping full technical accuracy",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piotr-oles/pi-extensions.git",
+    "directory": "packages/pi-caveman"
+  },
+  "keywords": [
+    "pi-package"
+  ],
+  "type": "module",
+  "files": [
+    "src",
+    "!src/tests",
+    "instructions"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "biome ci src/",
+    "fix": "biome check --write src/"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-agent-core": "^0.75.5",
+    "@earendil-works/pi-coding-agent": "^0.75.5",
+    "@marcfargas/pi-test-harness": "^0.6.1",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.1"
+  }
+}

--- a/packages/pi-caveman/package.json
+++ b/packages/pi-caveman/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pi-caveman",
+  "name": "@oles/pi-caveman",
   "version": "0.1.0",
   "description": "Pi Agent extension: respond in caveman mode — cut ~75% output tokens while keeping full technical accuracy",
   "repository": {

--- a/packages/pi-caveman/src/index.test.ts
+++ b/packages/pi-caveman/src/index.test.ts
@@ -1,12 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createTestSession, says, type TestSession, when } from "@marcfargas/pi-test-harness";
-import { afterEach, describe, expect, it } from "vitest";
-import piCaveman from "./index.js";
-
-function cavemanExtension() {
-  return (pi: any) => piCaveman(pi);
-}
+import { describe, expect, it } from "vitest";
+import { parseLevel } from "./level.js";
 
 describe("instruction files", () => {
   it.each(["lite", "full", "ultra"])("%s.md loads and starts with IMPORTANT directive", (level) => {
@@ -15,44 +10,14 @@ describe("instruction files", () => {
   });
 });
 
-describe("input auto-detection", { timeout: 30_000 }, () => {
-  let t: TestSession;
-  afterEach(() => t?.dispose());
-
-  it("activates full mode on 'caveman mode' trigger", async () => {
-    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
-    await t.run(when("use caveman mode", [says("ok")]));
-    const [notification] = t.events.uiCallsFor("notify");
-    expect(notification.args[0]).toBe("Caveman mode active. Drop articles, fragments ok.");
-    expect(notification.args[1]).toBe("info");
+describe("parseLevel", () => {
+  it.each(["off", "lite", "full", "ultra"])("parses '%s'", (level) => {
+    expect(parseLevel(level)).toBe(level);
   });
 
-  it("activates lite mode when 'lite' in trigger phrase", async () => {
-    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
-    await t.run(when("use caveman lite mode", [says("ok")]));
-    const [notification] = t.events.uiCallsFor("notify");
-    expect(notification.args[0]).toBe("Caveman Lite active. Drop filler, keep grammar.");
-  });
-
-  it("activates ultra mode when 'ultra' in trigger phrase", async () => {
-    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
-    await t.run(when("use caveman ultra mode", [says("ok")]));
-    const [notification] = t.events.uiCallsFor("notify");
-    expect(notification.args[0]).toBe("Caveman Ultra active. Maximum compression.");
-  });
-
-  it("deactivates on 'stop caveman' trigger", async () => {
-    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
-    await t.run(when("ok stop caveman now", [says("ok")]));
-    const [notification] = t.events.uiCallsFor("notify");
-    expect(notification.args[0]).toBe("Caveman go away.");
-    expect(notification.args[1]).toBe("info");
-  });
-
-  it("deactivates on 'normal mode' trigger", async () => {
-    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
-    await t.run(when("switch to normal mode", [says("ok")]));
-    const [notification] = t.events.uiCallsFor("notify");
-    expect(notification.args[0]).toBe("Caveman go away.");
+  it("returns null for unknown values", () => {
+    expect(parseLevel("extreme")).toBeNull();
+    expect(parseLevel("")).toBeNull();
+    expect(parseLevel(undefined)).toBeNull();
   });
 });

--- a/packages/pi-caveman/src/index.test.ts
+++ b/packages/pi-caveman/src/index.test.ts
@@ -1,23 +1,10 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { parseLevel } from "./level.js";
 
 describe("instruction files", () => {
   it.each(["lite", "full", "ultra"])("%s.md loads and starts with IMPORTANT directive", (level) => {
     const content = readFileSync(join(import.meta.dirname, `../instructions/${level}.md`), "utf-8");
     expect(content).toContain("IMPORTANT:");
-  });
-});
-
-describe("parseLevel", () => {
-  it.each(["off", "lite", "full", "ultra"])("parses '%s'", (level) => {
-    expect(parseLevel(level)).toBe(level);
-  });
-
-  it("returns null for unknown values", () => {
-    expect(parseLevel("extreme")).toBeNull();
-    expect(parseLevel("")).toBeNull();
-    expect(parseLevel(undefined)).toBeNull();
   });
 });

--- a/packages/pi-caveman/src/index.test.ts
+++ b/packages/pi-caveman/src/index.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createTestSession, says, type TestSession, when } from "@marcfargas/pi-test-harness";
+import { afterEach, describe, expect, it } from "vitest";
+import piCaveman from "./index.js";
+
+function cavemanExtension() {
+  return (pi: any) => piCaveman(pi);
+}
+
+describe("instruction files", () => {
+  it.each(["lite", "full", "ultra"])("%s.md loads and starts with IMPORTANT directive", (level) => {
+    const content = readFileSync(join(import.meta.dirname, `../instructions/${level}.md`), "utf-8");
+    expect(content).toContain("IMPORTANT:");
+  });
+});
+
+describe("input auto-detection", { timeout: 30_000 }, () => {
+  let t: TestSession;
+  afterEach(() => t?.dispose());
+
+  it("activates full mode on 'caveman mode' trigger", async () => {
+    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
+    await t.run(when("use caveman mode", [says("ok")]));
+    const [notification] = t.events.uiCallsFor("notify");
+    expect(notification.args[0]).toBe("Caveman mode active. Drop articles, fragments ok.");
+    expect(notification.args[1]).toBe("info");
+  });
+
+  it("activates lite mode when 'lite' in trigger phrase", async () => {
+    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
+    await t.run(when("use caveman lite mode", [says("ok")]));
+    const [notification] = t.events.uiCallsFor("notify");
+    expect(notification.args[0]).toBe("Caveman Lite active. Drop filler, keep grammar.");
+  });
+
+  it("activates ultra mode when 'ultra' in trigger phrase", async () => {
+    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
+    await t.run(when("use caveman ultra mode", [says("ok")]));
+    const [notification] = t.events.uiCallsFor("notify");
+    expect(notification.args[0]).toBe("Caveman Ultra active. Maximum compression.");
+  });
+
+  it("deactivates on 'stop caveman' trigger", async () => {
+    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
+    await t.run(when("ok stop caveman now", [says("ok")]));
+    const [notification] = t.events.uiCallsFor("notify");
+    expect(notification.args[0]).toBe("Caveman go away.");
+    expect(notification.args[1]).toBe("info");
+  });
+
+  it("deactivates on 'normal mode' trigger", async () => {
+    t = await createTestSession({ extensionFactories: [cavemanExtension()] });
+    await t.run(when("switch to normal mode", [says("ok")]));
+    const [notification] = t.events.uiCallsFor("notify");
+    expect(notification.args[0]).toBe("Caveman go away.");
+  });
+});

--- a/packages/pi-caveman/src/index.ts
+++ b/packages/pi-caveman/src/index.ts
@@ -15,7 +15,7 @@ export default function piCaveman(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     const level = getLevel(pi);
     if (level !== "off") {
-      ctx.ui.setStatus("pi-caveman", `🪨 ${level}`);
+      ctx.ui.notify(`Caveman mode: ${ctx.ui.theme.bold(level)}`, "info");
     }
   });
 

--- a/packages/pi-caveman/src/index.ts
+++ b/packages/pi-caveman/src/index.ts
@@ -1,0 +1,124 @@
+/**
+ * Pi Caveman Extension
+ *
+ * Inspired by https://github.com/JuliusBrussee/caveman
+ * Makes the agent speak like a caveman — cutting ~75% of output tokens
+ * while keeping full technical accuracy.
+ *
+ * Usage:
+ * - `/caveman`       — toggle caveman mode on/off
+ * - `/caveman lite`  — drop filler, keep grammar (professional)
+ * - `/caveman full`  — default caveman mode (drop articles, fragments ok)
+ * - `/caveman ultra` — maximum compression, telegraphic
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+type CavemanLevel = "off" | "lite" | "full" | "ultra";
+
+const ACTIVE_LEVELS = ["lite", "full", "ultra"] as const;
+type ActiveLevel = (typeof ACTIVE_LEVELS)[number];
+
+const instructionsDir = path.join(import.meta.dirname, "..", "instructions");
+
+const instructions: Record<ActiveLevel, string> = Object.fromEntries(
+  ACTIVE_LEVELS.map((level) => [
+    level,
+    fs.readFileSync(path.join(instructionsDir, `${level}.md`), "utf-8"),
+  ]),
+) as Record<ActiveLevel, string>;
+
+function isActiveLevel(value: string): value is ActiveLevel {
+  return (ACTIVE_LEVELS as readonly string[]).includes(value);
+}
+
+function formatNotification(level: CavemanLevel): string {
+  switch (level) {
+    case "off":
+      return "Caveman go away.";
+    case "lite":
+      return "Caveman Lite active. Drop filler, keep grammar.";
+    case "full":
+      return "Caveman mode active. Drop articles, fragments ok.";
+    case "ultra":
+      return "Caveman Ultra active. Maximum compression.";
+  }
+}
+
+export default function piCaveman(pi: ExtensionAPI) {
+  let currentLevel: CavemanLevel = "full";
+
+  pi.registerCommand("caveman", {
+    description: "Toggle caveman mode — speak like caveman, fewer tokens",
+    getArgumentCompletions: (prefix) => {
+      const levels: CavemanLevel[] = ["lite", "full", "ultra", "off"];
+      return levels.map((l) => ({ value: l, label: l })).filter((i) => i.value.startsWith(prefix));
+    },
+    handler: async (args, ctx) => {
+      const arg =
+        args
+          ?.trim()
+          .toLowerCase()
+          .split(/\s+/)[0]
+          .replace(/[^a-z]/g, "") ?? "";
+
+      if (!arg) {
+        currentLevel = currentLevel === "off" ? "full" : "off";
+      } else if (arg === "off") {
+        currentLevel = "off";
+      } else if (isActiveLevel(arg)) {
+        currentLevel = arg;
+      } else {
+        ctx.ui.notify(`Unknown level: ${args}. Use lite, full, ultra, or off.`, "error");
+        return;
+      }
+
+      ctx.ui.notify(formatNotification(currentLevel), "info");
+    },
+  });
+
+  pi.on("before_agent_start", async (event) => {
+    if (currentLevel === "off") {
+      return undefined;
+    }
+
+    return {
+      systemPrompt: `${event.systemPrompt}\n\n${instructions[currentLevel]}`,
+    };
+  });
+
+  pi.on("session_start", async () => {
+    currentLevel = "full";
+  });
+
+  pi.on("input", async (event, ctx) => {
+    const text = event.text.toLowerCase();
+
+    const stopTriggers = ["stop caveman", "normal mode"];
+    for (const stop of stopTriggers) {
+      if (text.includes(stop)) {
+        currentLevel = "off";
+        ctx.ui.notify(formatNotification("off"), "info");
+        return;
+      }
+    }
+
+    const activeTriggers = [
+      "caveman mode",
+      "talk like caveman",
+      "use caveman",
+      "less tokens",
+      "be brief",
+      "fewer tokens",
+    ];
+    for (const trigger of activeTriggers) {
+      if (text.includes(trigger)) {
+        currentLevel = text.includes("lite") ? "lite" : text.includes("ultra") ? "ultra" : "full";
+        ctx.ui.notify(formatNotification(currentLevel), "info");
+        return;
+      }
+    }
+  });
+}

--- a/packages/pi-caveman/src/index.ts
+++ b/packages/pi-caveman/src/index.ts
@@ -12,6 +12,13 @@ const instructions = {
 };
 
 export default function piCaveman(pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    const level = getLevel(pi);
+    if (level !== "off") {
+      ctx.ui.setStatus("pi-caveman", `🪨 ${level}`);
+    }
+  });
+
   pi.registerFlag("pi-caveman", {
     type: "string",
     description: "Caveman mode level: lite, full (default), or ultra. Set to off to disable.",

--- a/packages/pi-caveman/src/index.ts
+++ b/packages/pi-caveman/src/index.ts
@@ -1,124 +1,29 @@
-/**
- * Pi Caveman Extension
- *
- * Inspired by https://github.com/JuliusBrussee/caveman
- * Makes the agent speak like a caveman — cutting ~75% of output tokens
- * while keeping full technical accuracy.
- *
- * Usage:
- * - `/caveman`       — toggle caveman mode on/off
- * - `/caveman lite`  — drop filler, keep grammar (professional)
- * - `/caveman full`  — default caveman mode (drop articles, fragments ok)
- * - `/caveman ultra` — maximum compression, telegraphic
- */
-
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-
-type CavemanLevel = "off" | "lite" | "full" | "ultra";
-
-const ACTIVE_LEVELS = ["lite", "full", "ultra"] as const;
-type ActiveLevel = (typeof ACTIVE_LEVELS)[number];
+import { getLevel } from "./level.js";
 
 const instructionsDir = path.join(import.meta.dirname, "..", "instructions");
 
-const instructions: Record<ActiveLevel, string> = Object.fromEntries(
-  ACTIVE_LEVELS.map((level) => [
-    level,
-    fs.readFileSync(path.join(instructionsDir, `${level}.md`), "utf-8"),
-  ]),
-) as Record<ActiveLevel, string>;
-
-function isActiveLevel(value: string): value is ActiveLevel {
-  return (ACTIVE_LEVELS as readonly string[]).includes(value);
-}
-
-function formatNotification(level: CavemanLevel): string {
-  switch (level) {
-    case "off":
-      return "Caveman go away.";
-    case "lite":
-      return "Caveman Lite active. Drop filler, keep grammar.";
-    case "full":
-      return "Caveman mode active. Drop articles, fragments ok.";
-    case "ultra":
-      return "Caveman Ultra active. Maximum compression.";
-  }
-}
+const instructions = {
+  lite: fs.readFileSync(path.join(instructionsDir, "lite.md"), "utf-8"),
+  full: fs.readFileSync(path.join(instructionsDir, "full.md"), "utf-8"),
+  ultra: fs.readFileSync(path.join(instructionsDir, "ultra.md"), "utf-8"),
+};
 
 export default function piCaveman(pi: ExtensionAPI) {
-  let currentLevel: CavemanLevel = "full";
-
-  pi.registerCommand("caveman", {
-    description: "Toggle caveman mode — speak like caveman, fewer tokens",
-    getArgumentCompletions: (prefix) => {
-      const levels: CavemanLevel[] = ["lite", "full", "ultra", "off"];
-      return levels.map((l) => ({ value: l, label: l })).filter((i) => i.value.startsWith(prefix));
-    },
-    handler: async (args, ctx) => {
-      const arg =
-        args
-          ?.trim()
-          .toLowerCase()
-          .split(/\s+/)[0]
-          .replace(/[^a-z]/g, "") ?? "";
-
-      if (!arg) {
-        currentLevel = currentLevel === "off" ? "full" : "off";
-      } else if (arg === "off") {
-        currentLevel = "off";
-      } else if (isActiveLevel(arg)) {
-        currentLevel = arg;
-      } else {
-        ctx.ui.notify(`Unknown level: ${args}. Use lite, full, ultra, or off.`, "error");
-        return;
-      }
-
-      ctx.ui.notify(formatNotification(currentLevel), "info");
-    },
+  pi.registerFlag("pi-caveman", {
+    type: "string",
+    description: "Caveman mode level: lite, full (default), or ultra. Set to off to disable.",
   });
 
   pi.on("before_agent_start", async (event) => {
-    if (currentLevel === "off") {
+    const level = getLevel(pi);
+    if (level === "off") {
       return undefined;
     }
-
     return {
-      systemPrompt: `${event.systemPrompt}\n\n${instructions[currentLevel]}`,
+      systemPrompt: `${event.systemPrompt}\n\n${instructions[level]}`,
     };
-  });
-
-  pi.on("session_start", async () => {
-    currentLevel = "full";
-  });
-
-  pi.on("input", async (event, ctx) => {
-    const text = event.text.toLowerCase();
-
-    const stopTriggers = ["stop caveman", "normal mode"];
-    for (const stop of stopTriggers) {
-      if (text.includes(stop)) {
-        currentLevel = "off";
-        ctx.ui.notify(formatNotification("off"), "info");
-        return;
-      }
-    }
-
-    const activeTriggers = [
-      "caveman mode",
-      "talk like caveman",
-      "use caveman",
-      "less tokens",
-      "be brief",
-      "fewer tokens",
-    ];
-    for (const trigger of activeTriggers) {
-      if (text.includes(trigger)) {
-        currentLevel = text.includes("lite") ? "lite" : text.includes("ultra") ? "ultra" : "full";
-        ctx.ui.notify(formatNotification(currentLevel), "info");
-        return;
-      }
-    }
   });
 }

--- a/packages/pi-caveman/src/level.test.ts
+++ b/packages/pi-caveman/src/level.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { parseLevel } from "./level.js";
+
+describe("parseLevel", () => {
+  it.each(["off", "lite", "full", "ultra"])("parses '%s'", (level) => {
+    expect(parseLevel(level)).toBe(level);
+  });
+
+  it("returns null for unknown values", () => {
+    expect(parseLevel("extreme")).toBeNull();
+    expect(parseLevel("")).toBeNull();
+    expect(parseLevel(undefined)).toBeNull();
+  });
+});

--- a/packages/pi-caveman/src/level.ts
+++ b/packages/pi-caveman/src/level.ts
@@ -1,0 +1,19 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export type CavemanLevel = "off" | "lite" | "full" | "ultra";
+
+export function parseLevel(value: string | undefined): CavemanLevel | null {
+  if (value === "off" || value === "lite" || value === "full" || value === "ultra") {
+    return value;
+  }
+  return null;
+}
+
+export function getLevel(pi: ExtensionAPI): CavemanLevel {
+  const flag = pi.getFlag("pi-caveman");
+  return (
+    parseLevel(typeof flag === "string" ? flag : undefined) ??
+    parseLevel(process.env.PI_CAVEMAN) ??
+    "full"
+  );
+}

--- a/packages/pi-caveman/tsconfig.json
+++ b/packages/pi-caveman/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/pi-caveman/vitest.config.ts
+++ b/packages/pi-caveman/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,24 @@ importers:
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.9.1)
 
+  packages/pi-caveman:
+    devDependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@marcfargas/pi-test-harness':
+        specifier: ^0.6.1
+        version: 0.6.1(@earendil-works/pi-agent-core@0.75.5(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-ai@0.75.5(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.75.5(ws@8.21.0)(zod@4.4.3))
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
+
   packages/pi-fence:
     dependencies:
       web-tree-sitter:


### PR DESCRIPTION
Adds `@oles/pi-caveman` — a pi agent extension that responds in caveman mode, cutting ~75% output tokens while keeping full technical accuracy.

## What it does

Injects level-specific instructions into the system prompt at session start. Level is immutable for the session.

## Levels

| Level | Behavior |
|-------|----------|
| `lite` | Keep grammar. Drop filler and pleasantries. |
| `full` | Drop articles, filler, pleasantries. Fragments ok. (default) |
| `ultra` | Maximum compression. Symbols over words. |

## Usage

```bash
pi --pi-caveman full     # default
pi --pi-caveman lite
pi --pi-caveman ultra
pi --pi-caveman off

PI_CAVEMAN=full pi
```

## Changes

- `packages/pi-caveman/` — new package
  - `src/index.ts` — registers flag, sets footer status, injects system prompt
  - `src/level.ts` — `parseLevel` / `getLevel` (flag → env → `full`)
  - `instructions/{lite,full,ultra}.md` — imperative directives loaded at init
  - Tests: 8 passing (instruction file checks + `parseLevel` unit tests)