### PR TITLE
pi-plan: rename tool review-plan to review_plan

### DIFF
--- a/packages/pi-plan/src/index.test.ts
+++ b/packages/pi-plan/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import piPlan from "./index.js";
 
 describe("piPlan extension", () => {
-  it("registers the review-plan tool", () => {
+  it("registers the review_plan tool", () => {
     const registerTool = vi.fn();
     const pi = { registerTool, exec: vi.fn() };
 
@@ -10,7 +10,7 @@ describe("piPlan extension", () => {
 
     expect(registerTool).toHaveBeenCalledOnce();
     const [tool] = registerTool.mock.calls[0];
-    expect(tool.name).toBe("review-plan");
+    expect(tool.name).toBe("review_plan");
   });
 
   it("binds exec to pi instance", () => {

--- a/packages/pi-plan/src/plan-tool.test.ts
+++ b/packages/pi-plan/src/plan-tool.test.ts
@@ -198,7 +198,7 @@ describe("createReviewPlanTool - execute with UI", () => {
     expect((result.details as any).diff).not.toBe("");
     expect((result.details as any).diff).toMatch(/\+.*NEEDS CHANGE/);
     expect(textContent(result)).toContain("Address user comments");
-    expect(textContent(result)).toContain("call review-plan again");
+    expect(textContent(result)).toContain("call review_plan again");
   });
 
   it("returns request-changes with empty diff when user requests changes without editing", async () => {

--- a/packages/pi-plan/src/plan-tool.ts
+++ b/packages/pi-plan/src/plan-tool.ts
@@ -14,7 +14,7 @@ const ReviewPlanParams = Type.Object({
   planPath: Type.String({
     description:
       "Path to the plan file relative to ~/.pi/plan/ (e.g. 'my-repo/auth-refactor.md'). " +
-      "Write the file first via the write tool, then call review-plan.",
+      "Write the file first via the write tool, then call review_plan.",
   }),
 });
 
@@ -31,12 +31,12 @@ export function createReviewPlanTool(
   plansDir = PLANS_DIR,
 ): ToolDefinition<typeof ReviewPlanParams, PlanReviewToolDetails> {
   return {
-    name: "review-plan",
+    name: "review_plan",
     label: "Review Plan",
     description:
       "Open an existing plan file for user review. Write the file first, then call this tool.",
     promptGuidelines: [
-      "Write the plan file to ~/.pi/plan/<repo>/<name>.md first, then call review-plan with the relative path.",
+      "For planning, write the plan file to ~/.pi/plan/<repo>/<name>.md first, then call review_plan with the <repo>/<name>.md path. Never execute plan without explicit approval.",
     ],
     parameters: ReviewPlanParams,
 
@@ -122,7 +122,7 @@ export function createReviewPlanTool(
                 text:
                   `User edited the "${planName}" plan:\n\n${diff}\n\n` +
                   "The changes mentioned above has been already saved in the plan file.\n" +
-                  "Address user comments, fixup the plan, then call review-plan again.",
+                  "Address user comments, fixup the plan, then call review_plan again.",
               },
             ],
             details: { result: "request-changes", planPath, diff },
@@ -207,7 +207,7 @@ class PlanReviewResult implements Component {
       }
       case "question": {
         this.container.addChild(
-          new Text(theme.fg("accent", `Question: ${details.message ?? ""}`), 0, 0),
+          new Text(theme.fg("accent", `Question: `) + `${details.message ?? ""}`, 0, 0),
         );
         break;
       }


### PR DESCRIPTION
- Rename tool `review-plan` → `review_plan` (underscore for consistency)
- Update prompt guidelines to require explicit user approval before executing plan
- Fix `Text` component `fg` concatenation for question case
- Update test assertion to match new tool name