### PR TITLE
feat: pi-reflag — transparent grep → rg rewriting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ Makes the agent respond in caveman mode — cuts ~75% of output tokens while kee
 ### `pi-plan` (`packages/pi-plan`)
 Adds a `review-plan` tool that writes a named markdown plan to `~/.pi/plan/<repo>/<name>.md`, opens it in Zed, commits it to a git repo inside `~/.pi/plan/`, and shows an interactive terminal widget so the user can confirm, request changes, or reply freely before the agent proceeds.
 
+### `pi-reflag` (`packages/pi-reflag`)
+Intercepts `bash` tool calls and rewrites `grep` commands to `rg` (ripgrep) transparently before execution. Handles flag translation (drops `-r`/`-R`/`-E`, maps long flags, converts `--include`/`--exclude` to `-g` globs, converts BRE patterns to ERE). Skips commands with subshells. Shows a user-visible toast notification on rewrite — agent never sees it. Controlled by the `pi-reflag-grep` flag (`on` by default, set to `off` to disable).
+
 ### `pi-sem` (`packages/pi-sem`) — private
 Wraps the [`sem`](https://github.com/piotr-oles/sem) CLI as four pi tools: `sem_context`, `sem_entities`, `sem_impact`, `sem_diff`. Gives the model semantic understanding of code structure without reading entire files.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A monorepo of [pi coding agent](https://github.com/earendil-works/pi) extensions
 | [`@piotr-oles/pi-fence`](packages/pi-fence) | Detects and handles decorative fence/divider comments in written code — warn, block, or auto-remove |
 | [`@piotr-oles/pi-caveman`](packages/pi-caveman) | Makes the agent respond in caveman mode — cuts ~75% of output tokens while keeping full technical accuracy |
 | [`@piotr-oles/pi-plan`](packages/pi-plan) | Adds a `plan` tool — saves a named markdown plan to disk, opens it for review, and waits for user confirmation before proceeding |
+| [`@piotr-oles/pi-reflag`](packages/pi-reflag) | Transparently rewrites `grep` commands to `rg` (ripgrep) before they execute — faster searches, zero agent behavior change |
 
 ## Development
 

--- a/packages/pi-reflag/README.md
+++ b/packages/pi-reflag/README.md
@@ -1,0 +1,73 @@
+# pi-reflag
+
+A [pi coding agent](https://github.com/earendil-works/pi) extension that transparently rewrites `grep` commands to [`rg`](https://github.com/BurntSushi/ripgrep) (ripgrep) before they execute — faster searches with zero agent behavior change.
+
+## Install
+
+```bash
+pi install npm:@piotr-oles/pi-reflag
+```
+
+Requires `rg` on `$PATH`. Install ripgrep via your package manager if needed:
+
+```bash
+brew install ripgrep      # macOS
+apt install ripgrep       # Debian/Ubuntu
+```
+
+## How it works
+
+Intercepts `bash` tool calls in the `tool_call` event. When the command starts with `grep` (including piped commands like `grep … | head`), it translates the arguments to their `rg` equivalents and rewrites the command in place before execution. The agent never sees the rewrite — only a user-visible toast notification is shown.
+
+**What gets translated:**
+
+| grep flag | rg equivalent |
+|---|---|
+| `-r`, `-R`, `--recursive` | dropped (rg is recursive by default) |
+| `-i`, `--ignore-case` | `-i` |
+| `-n`, `--line-number` | `-n` |
+| `-v`, `--invert-match` | `-v` |
+| `-w`, `--word-regexp` | `-w` |
+| `-l`, `--files-with-matches` | `-l` |
+| `-c`, `--count` | `-c` |
+| `-o`, `--only-matching` | `-o` |
+| `-E`, `--extended-regexp` | dropped (rg uses ERE by default) |
+| `-G`, `--basic-regexp` | dropped, pattern converted from BRE to ERE |
+| `-F`, `--fixed-strings` | `-F` |
+| `-P`, `--perl-regexp` | `-P` |
+| `-A`, `-B`, `-C` | passed through |
+| `--include=<glob>` | `-g <glob>` |
+| `--exclude=<glob>` | `-g !<glob>` |
+| `--exclude-dir=<dir>` | `-g !<dir>/` |
+| `-s` | `--no-messages` |
+| `-N` (numeric context) | `-C N` |
+
+Subshell constructs (`$(…)`, `(…)`) are left untouched to avoid misinterpreting nested commands.
+
+## Usage
+
+The extension is active by default. Disable it per-session with the `--pi-reflag-grep` flag:
+
+```bash
+pi --pi-reflag-grep off
+```
+
+## Thanks
+
+- [ripgrep](https://github.com/BurntSushi/ripgrep) by Andrew Gallant — the fast, modern grep replacement this extension routes to
+- [greprip-rs](https://github.com/kaofelix/greprip-rs) by kaofelix — the grep → rg argument translation logic is ported from that project (MIT)
+
+## Development
+
+```bash
+pnpm install
+pnpm test
+pnpm typecheck
+pnpm check
+```
+
+To test changes manually:
+
+```bash
+pi -e packages/pi-reflag/src/index.ts
+```

--- a/packages/pi-reflag/package.json
+++ b/packages/pi-reflag/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@piotr-oles/pi-reflag",
+  "version": "0.1.0",
+  "description": "Pi Agent extension: transparently rewrite grep commands to rg (ripgrep) for faster searches",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piotr-oles/pi-extensions.git",
+    "directory": "packages/pi-reflag"
+  },
+  "keywords": [
+    "pi-package"
+  ],
+  "type": "module",
+  "files": [
+    "src",
+    "!src/*.test.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "biome ci src/",
+    "fix": "biome check --write src/"
+  },
+  "dependencies": {
+    "shell-quote": "^1.8.4"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-agent-core": "^0.75.5",
+    "@earendil-works/pi-coding-agent": "^0.75.5",
+    "@types/shell-quote": "^1.7.5",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.1"
+  }
+}

--- a/packages/pi-reflag/src/grep.test.ts
+++ b/packages/pi-reflag/src/grep.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for grep→rg argument translation.
+ * Ported from:
+ *   - greprip-rs/tests/test_grep_to_rg.rs
+ *   - greprip-rs/src/grg.rs (inline #[cfg(test)] block)
+ */
+import { describe, expect, it } from "vitest";
+import { translateGrepArgs } from "./grep.js";
+
+function t(args: string[]): string[] {
+  return translateGrepArgs(args);
+}
+
+describe("basic patterns", () => {
+  it("simple pattern and file", () => {
+    expect(t(["hello", "file.txt"])).toEqual(["hello", "file.txt"]);
+  });
+
+  it("pattern only", () => {
+    expect(t(["hello"])).toEqual(["hello"]);
+  });
+});
+
+describe("common flags", () => {
+  it("case insensitive -i", () => {
+    expect(t(["-i", "hello", "file.txt"])).toEqual(["-i", "hello", "file.txt"]);
+  });
+
+  it("line numbers -n", () => {
+    expect(t(["-n", "hello", "file.txt"])).toEqual(["-n", "hello", "file.txt"]);
+  });
+
+  it("invert match -v", () => {
+    expect(t(["-v", "hello", "file.txt"])).toEqual(["-v", "hello", "file.txt"]);
+  });
+
+  it("word boundary -w", () => {
+    expect(t(["-w", "foo", "file.txt"])).toEqual(["-w", "foo", "file.txt"]);
+  });
+
+  it("files with matches -l", () => {
+    expect(t(["-l", "hello", "dir/"])).toEqual(["-l", "hello", "dir/"]);
+  });
+
+  it("count -c", () => {
+    expect(t(["-c", "hello", "file.txt"])).toEqual(["-c", "hello", "file.txt"]);
+  });
+
+  it("only matching -o", () => {
+    expect(t(["-o", "hello", "file.txt"])).toEqual(["-o", "hello", "file.txt"]);
+  });
+
+  it("quiet -q", () => {
+    expect(t(["-q", "hello", "file.txt"])).toContain("-q");
+  });
+
+  it("fixed strings -F", () => {
+    const result = t(["-F", "hello.world", "file.txt"]);
+    expect(result).toContain("-F");
+  });
+
+  it("perl regex -P", () => {
+    const result = t(["-P", "\\bhello\\b", "file.txt"]);
+    expect(result).toContain("-P");
+  });
+
+  it("null separated --null", () => {
+    const result = t(["-l", "--null", "hello", "dir/"]);
+    expect(result).toContain("--null");
+  });
+});
+
+describe("dropped flags", () => {
+  it("drops -r (rg default)", () => {
+    expect(t(["-r", "hello", "dir/"])).toEqual(["hello", "dir/"]);
+  });
+
+  it("drops -R", () => {
+    expect(t(["-R", "hello", "dir/"])).toEqual(["hello", "dir/"]);
+  });
+
+  it("drops -E (rg default)", () => {
+    expect(t(["-E", "foo|bar", "file.txt"])).toEqual(["foo|bar", "file.txt"]);
+  });
+
+  it("drops -G", () => {
+    expect(t(["-G", "hello", "file.txt"])).toEqual(["hello", "file.txt"]);
+  });
+
+  it("drops --recursive", () => {
+    const result = t(["--recursive", "hello", "dir/"]);
+    expect(result).toContain("hello");
+    expect(result).not.toContain("--recursive");
+  });
+
+  it("drops --extended-regexp", () => {
+    const result = t(["--extended-regexp", "foo|bar", "file.txt"]);
+    expect(result).not.toContain("--extended-regexp");
+  });
+
+  it("drops --basic-regexp", () => {
+    const result = t(["--basic-regexp", "hello", "file.txt"]);
+    expect(result).not.toContain("--basic-regexp");
+  });
+});
+
+describe("suppress errors", () => {
+  it("maps -s to --no-messages", () => {
+    const result = t(["-s", "hello", "file.txt"]);
+    expect(result).toContain("--no-messages");
+    expect(result).not.toContain("-s");
+  });
+});
+
+describe("combined short flags", () => {
+  it("drops -r but keeps -i in -ri", () => {
+    const result = t(["-ri", "hello", "dir/"]);
+    expect(result).toContain("-i");
+    expect(result).not.toContain("-r");
+    expect(result).toContain("hello");
+    expect(result).toContain("dir/");
+  });
+
+  it("multiple separate flags -i -n", () => {
+    const result = t(["-i", "-n", "hello", "file.txt"]);
+    expect(result).toContain("-i");
+    expect(result).toContain("-n");
+    expect(result).toContain("hello");
+  });
+
+  it("combined -rn drops -r keeps -n", () => {
+    const result = t(["-rn", "hello", "dir/"]);
+    expect(result).toContain("-n");
+    expect(result).not.toContain("-r");
+  });
+});
+
+describe("context lines", () => {
+  it("after context -A", () => {
+    const result = t(["-A", "3", "hello", "file.txt"]);
+    expect(result).toContain("-A");
+    expect(result).toContain("3");
+  });
+
+  it("before context -B", () => {
+    const result = t(["-B", "2", "hello", "file.txt"]);
+    expect(result).toContain("-B");
+    expect(result).toContain("2");
+  });
+
+  it("context both sides -C", () => {
+    const result = t(["-C", "5", "hello", "file.txt"]);
+    expect(result).toContain("-C");
+    expect(result).toContain("5");
+  });
+
+  it("numeric shorthand -3 → -C 3", () => {
+    const result = t(["-3", "hello", "file.txt"]);
+    expect(result).toContain("-C");
+    expect(result).toContain("3");
+    expect(result).not.toContain("-3");
+  });
+});
+
+describe("explicit pattern -e", () => {
+  it("single pattern with -e", () => {
+    const result = t(["-e", "hello", "file.txt"]);
+    expect(result).toContain("-e");
+    expect(result).toContain("hello");
+  });
+
+  it("multiple patterns with -e", () => {
+    const result = t(["-e", "hello", "-e", "world", "file.txt"]);
+    expect(result.filter((x) => x === "-e")).toHaveLength(2);
+    expect(result).toContain("hello");
+    expect(result).toContain("world");
+  });
+});
+
+describe("pattern file -f", () => {
+  it("patterns from file -f", () => {
+    const result = t(["-f", "patterns.txt", "file.txt"]);
+    expect(result).toContain("-f");
+    expect(result).toContain("patterns.txt");
+  });
+});
+
+describe("include/exclude", () => {
+  it("--include=*.py → -g *.py", () => {
+    const result = t(["--include=*.py", "-r", "hello", "dir/"]);
+    expect(result).toContain("-g");
+    expect(result.join(" ")).toContain("*.py");
+  });
+
+  it("--exclude=*.pyc → -g !*.pyc", () => {
+    const result = t(["--exclude=*.pyc", "-r", "hello", "dir/"]);
+    expect(result).toContain("-g");
+    expect(result.join(" ")).toContain("!*.pyc");
+  });
+
+  it("--exclude-dir=node_modules → -g !node_modules/", () => {
+    const result = t(["--exclude-dir=node_modules", "-r", "hello", "dir/"]);
+    expect(result).toContain("-g");
+    expect(result.join(" ")).toContain("!node_modules/");
+  });
+});
+
+describe("long options", () => {
+  it("--ignore-case", () => {
+    const result = t(["--ignore-case", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-i|--ignore-case/);
+  });
+
+  it("--line-number", () => {
+    const result = t(["--line-number", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-n|--line-number/);
+  });
+
+  it("--invert-match", () => {
+    const result = t(["--invert-match", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-v|--invert-match/);
+  });
+
+  it("--word-regexp", () => {
+    const result = t(["--word-regexp", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-w|--word-regexp/);
+  });
+
+  it("--files-with-matches", () => {
+    const result = t(["--files-with-matches", "hello", "dir/"]);
+    expect(result.join(" ")).toMatch(/-l|--files-with-matches/);
+  });
+
+  it("--count", () => {
+    const result = t(["--count", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-c|--count/);
+  });
+
+  it("--quiet", () => {
+    const result = t(["--quiet", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-q|--quiet/);
+  });
+
+  it("--silent", () => {
+    const result = t(["--silent", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-q|--silent/);
+  });
+
+  it("--only-matching", () => {
+    const result = t(["--only-matching", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-o|--only-matching/);
+  });
+
+  it("--no-filename", () => {
+    const result = t(["--no-filename", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-h|--no-filename/);
+  });
+
+  it("--with-filename", () => {
+    const result = t(["--with-filename", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/-H|--with-filename/);
+  });
+
+  it("unknown long option passed through", () => {
+    const result = t(["--some-unknown-flag", "hello", "file.txt"]);
+    expect(result).toContain("--some-unknown-flag");
+  });
+});
+
+describe("color handling", () => {
+  it("--color=always pass through", () => {
+    const result = t(["--color=always", "hello", "file.txt"]);
+    expect(result).toContain("--color=always");
+  });
+
+  it("--color=never pass through", () => {
+    const result = t(["--color=never", "hello", "file.txt"]);
+    expect(result).toContain("--color=never");
+  });
+
+  it("--color=auto pass through", () => {
+    const result = t(["--color=auto", "hello", "file.txt"]);
+    expect(result).toContain("--color=auto");
+  });
+
+  it("--color alone → --color=always", () => {
+    const result = t(["--color", "hello", "file.txt"]);
+    expect(result.join(" ")).toMatch(/--color=always|--color/);
+  });
+});
+
+describe("--regexp= long option", () => {
+  it("--regexp=PAT → -e PAT", () => {
+    const result = t(["--regexp=hello", "file.txt"]);
+    expect(result).toContain("-e");
+    expect(result).toContain("hello");
+  });
+
+  it("--regexp= with BRE alternation converts", () => {
+    const result = t(["--regexp=foo\\|bar", "file.txt"]);
+    expect(result).toContain("-e");
+    expect(result).toContain("foo|bar");
+  });
+});
+
+describe("BRE to ERE conversion", () => {
+  it("alternation \\| → |", () => {
+    expect(t(["foo\\|bar", "file.txt"])).toEqual(["foo|bar", "file.txt"]);
+  });
+
+  it("one-or-more \\+ → +", () => {
+    expect(t(["foo\\+", "file.txt"])).toEqual(["foo+", "file.txt"]);
+  });
+
+  it("zero-or-one \\? → ?", () => {
+    expect(t(["foo\\?", "file.txt"])).toEqual(["foo?", "file.txt"]);
+  });
+
+  it("grouping \\(...\\) → (...)", () => {
+    expect(t(["\\(foo\\)\\?", "file.txt"])).toEqual(["(foo)?", "file.txt"]);
+  });
+
+  it("quantifier \\{1,3\\} → {1,3}", () => {
+    expect(t(["foo\\{1,3\\}", "file.txt"])).toEqual(["foo{1,3}", "file.txt"]);
+  });
+
+  it("combined operators \\(foo\\|bar\\)\\+", () => {
+    expect(t(["\\(foo\\|bar\\)\\+", "file.txt"])).toEqual(["(foo|bar)+", "file.txt"]);
+  });
+
+  it("BRE conversion applied to -e pattern", () => {
+    expect(t(["-e", "foo\\|bar", "file.txt"])).toEqual(["-e", "foo|bar", "file.txt"]);
+  });
+});
+
+describe("fixed strings skip BRE conversion", () => {
+  it("-F suppresses BRE conversion on positional pattern", () => {
+    const result = t(["-F", "foo\\|bar", "file.txt"]);
+    expect(result).toContain("foo\\|bar");
+  });
+
+  it("--fixed-strings suppresses BRE conversion", () => {
+    const result = t(["--fixed-strings", "foo\\|bar", "file.txt"]);
+    expect(result).toContain("foo\\|bar");
+  });
+
+  it("combined -Fi suppresses BRE conversion", () => {
+    const result = t(["-Fi", "foo\\|bar", "file.txt"]);
+    expect(result).toContain("foo\\|bar");
+  });
+
+  it("-F with -e pattern suppresses conversion", () => {
+    const result = t(["-F", "-e", "foo\\|bar", "file.txt"]);
+    expect(result).toContain("foo\\|bar");
+    expect(result).not.toContain("foo|bar");
+  });
+});

--- a/packages/pi-reflag/src/grep.ts
+++ b/packages/pi-reflag/src/grep.ts
@@ -1,0 +1,207 @@
+/**
+ * Translate grep command-line arguments to rg (ripgrep) equivalents.
+ *
+ * Ported from greprip-rs/src/grg.rs (MIT license, kaofelix).
+ */
+
+function convertBreToEre(pattern: string): string {
+  return pattern
+    .replace(/\\\(/g, "(")
+    .replace(/\\\)/g, ")")
+    .replace(/\\\|/g, "|")
+    .replace(/\\\+/g, "+")
+    .replace(/\\\?/g, "?")
+    .replace(/\\\{/g, "{")
+    .replace(/\\\}/g, "}");
+}
+
+function hasFixedStringsFlag(args: string[]): boolean {
+  for (const arg of args) {
+    if (arg === "-F" || arg === "--fixed-strings") {
+      return true;
+    }
+    if (arg.startsWith("-") && !arg.startsWith("--") && arg.length > 1 && arg.includes("F")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const DROP_SHORT: ReadonlySet<string> = new Set(["-r", "-R", "-E", "-G"]);
+const DROP_LONG: ReadonlySet<string> = new Set([
+  "--recursive",
+  "--extended-regexp",
+  "--basic-regexp",
+]);
+
+const PASSTHROUGH_NO_ARG: ReadonlySet<string> = new Set([
+  "-i",
+  "-n",
+  "-v",
+  "-w",
+  "-l",
+  "-c",
+  "-o",
+  "-h",
+  "-H",
+  "-q",
+  "-F",
+  "-P",
+  "--null",
+]);
+
+const PASSTHROUGH_WITH_ARG: ReadonlySet<string> = new Set(["-A", "-B", "-C", "-f", "-m"]);
+
+const LONG_TO_SHORT: ReadonlyMap<string, string | null> = new Map([
+  ["--ignore-case", "-i"],
+  ["--line-number", "-n"],
+  ["--invert-match", "-v"],
+  ["--word-regexp", "-w"],
+  ["--files-with-matches", "-l"],
+  ["--count", "-c"],
+  ["--only-matching", "-o"],
+  ["--no-filename", "-h"],
+  ["--with-filename", "-H"],
+  ["--quiet", "-q"],
+  ["--silent", "-q"],
+  ["--fixed-strings", "-F"],
+  ["--perl-regexp", "-P"],
+  ["--extended-regexp", null],
+  ["--basic-regexp", null],
+  ["--recursive", null],
+]);
+
+export function translateGrepArgs(args: string[]): string[] {
+  const fixedStrings = hasFixedStringsFlag(args);
+  const result: string[] = [];
+  let i = 0;
+  let patternSeen = false;
+
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg.startsWith("-") && arg.length > 1 && /^-\d+$/.test(arg)) {
+      result.push("-C", arg.slice(1));
+      i++;
+      continue;
+    }
+
+    if (DROP_SHORT.has(arg)) {
+      i++;
+      continue;
+    }
+
+    if (arg === "-s") {
+      result.push("--no-messages");
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("--include=")) {
+      result.push("-g", arg.slice("--include=".length));
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("--exclude=")) {
+      result.push("-g", `!${arg.slice("--exclude=".length)}`);
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("--exclude-dir=")) {
+      result.push("-g", `!${arg.slice("--exclude-dir=".length)}/`);
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("--regexp=")) {
+      const pattern = arg.slice("--regexp=".length);
+      result.push("-e", fixedStrings ? pattern : convertBreToEre(pattern));
+      i++;
+      continue;
+    }
+
+    if (arg === "--color") {
+      result.push("--color=always");
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("--color=")) {
+      result.push(arg);
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("--")) {
+      if (DROP_LONG.has(arg)) {
+        i++;
+        continue;
+      }
+      if (LONG_TO_SHORT.has(arg)) {
+        const mapped = LONG_TO_SHORT.get(arg);
+        if (mapped !== null && mapped !== undefined) {
+          result.push(mapped);
+        }
+        i++;
+        continue;
+      }
+      result.push(arg);
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("-") && arg.length > 2 && !/^-\d/.test(arg)) {
+      for (const c of arg.slice(1)) {
+        const flag = `-${c}`;
+        if (DROP_SHORT.has(flag)) {
+          continue;
+        }
+        if (flag === "-s") {
+          result.push("--no-messages");
+          continue;
+        }
+        result.push(flag);
+      }
+      i++;
+      continue;
+    }
+
+    if (arg === "-e") {
+      result.push("-e");
+      if (i + 1 < args.length) {
+        i++;
+        result.push(fixedStrings ? args[i] : convertBreToEre(args[i]));
+      }
+      i++;
+      continue;
+    }
+
+    if (PASSTHROUGH_NO_ARG.has(arg)) {
+      result.push(arg);
+      i++;
+      continue;
+    }
+
+    if (PASSTHROUGH_WITH_ARG.has(arg)) {
+      result.push(arg);
+      if (i + 1 < args.length) {
+        i++;
+        result.push(args[i]);
+      }
+      i++;
+      continue;
+    }
+
+    if (!patternSeen) {
+      result.push(fixedStrings ? arg : convertBreToEre(arg));
+      patternSeen = true;
+    } else {
+      result.push(arg);
+    }
+    i++;
+  }
+
+  return result;
+}

--- a/packages/pi-reflag/src/index.ts
+++ b/packages/pi-reflag/src/index.ts
@@ -1,0 +1,28 @@
+import { type ExtensionAPI, isToolCallEventType } from "@earendil-works/pi-coding-agent";
+import { rewriteCommand } from "./shell.js";
+
+export default function piReflag(pi: ExtensionAPI): void {
+  pi.registerFlag("pi-reflag-grep", {
+    type: "string",
+    description: "grep → rg rewriting: on (default) or off",
+  });
+
+  pi.on("tool_call", async (event, ctx) => {
+    if (!isToolCallEventType("bash", event)) {
+      return undefined;
+    }
+    if (pi.getFlag("pi-reflag-grep") === "off") {
+      return undefined;
+    }
+
+    const original = event.input.command;
+    const { rewritten, changed } = rewriteCommand(original);
+    if (!changed) {
+      return undefined;
+    }
+
+    event.input.command = rewritten;
+    ctx.ui.notify(`pi-reflag: \`${original}\` → \`${rewritten}\``, "info");
+    return undefined;
+  });
+}

--- a/packages/pi-reflag/src/shell.test.ts
+++ b/packages/pi-reflag/src/shell.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { rewriteCommand } from "./shell.js";
+
+function rewritten(cmd: string): string {
+  return rewriteCommand(cmd).rewritten;
+}
+
+function changed(cmd: string): boolean {
+  return rewriteCommand(cmd).changed;
+}
+
+describe("no grep — unchanged", () => {
+  it("no grep at all", () => {
+    expect(changed("echo hello")).toBe(false);
+  });
+
+  it("grep in middle of segment (not first token)", () => {
+    expect(changed("echo grep")).toBe(false);
+  });
+
+  it("absolute path grep", () => {
+    expect(changed("/usr/bin/grep pattern file.txt")).toBe(false);
+  });
+
+  it("rg command untouched", () => {
+    expect(changed("rg pattern src/")).toBe(false);
+  });
+});
+
+describe("simple grep rewrites", () => {
+  it("pattern and file", () => {
+    const r = rewritten("grep hello file.txt");
+    expect(r).toContain("rg");
+    expect(r).toContain("hello");
+    expect(r).toContain("file.txt");
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+
+  it("recursive flag dropped", () => {
+    const r = rewritten("grep -rn hello src/");
+    expect(r).toContain("rg");
+    expect(r).toContain("-n");
+    expect(r).not.toContain("-r");
+    expect(changed("grep -rn hello src/")).toBe(true);
+  });
+
+  it("case insensitive kept", () => {
+    const r = rewritten("grep -i hello file.txt");
+    expect(r).toContain("-i");
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+
+  it("extended regex flag dropped", () => {
+    const r = rewritten('grep -E "foo|bar" file.txt');
+    expect(r).not.toContain("-E");
+    // quote() shell-escapes | to \| — check | is present in some form
+    expect(r).toMatch(/foo[\\]?\|bar/);
+    expect(r).toContain("rg");
+  });
+
+  it("quoted pattern preserved as single arg", () => {
+    const r = rewritten("grep 'hello world' file.txt");
+    expect(r).toContain("rg");
+    expect(r).toContain("hello world");
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+});
+
+describe("pipeline rewrites", () => {
+  it("grep after pipe", () => {
+    const r = rewritten("cat file.txt | grep hello");
+    expect(r).toContain("cat");
+    expect(r).toContain("|");
+    expect(r).toContain("rg");
+    expect(r).not.toMatch(/\bgrep\b/);
+    expect(changed("cat file.txt | grep hello")).toBe(true);
+  });
+
+  it("both sides of pipe are grep", () => {
+    const r = rewritten("grep foo file.txt | grep bar");
+    expect(r.match(/\brg\b/g)).toHaveLength(2);
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+
+  it("only second segment is grep", () => {
+    const r = rewritten("echo something | grep pattern");
+    expect(r).toContain("echo something");
+    expect(r).toContain("rg");
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+});
+
+describe("shell operators", () => {
+  it("grep with && operator", () => {
+    const r = rewritten("grep foo file.txt && echo done");
+    expect(r).toContain("rg");
+    expect(r).toContain("&&");
+    expect(r).toContain("echo done");
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+
+  it("grep with ; separator", () => {
+    const r = rewritten("grep foo file.txt ; grep bar file.txt");
+    expect(r.match(/\brg\b/g)).toHaveLength(2);
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+
+  it("grep with || operator", () => {
+    const r = rewritten("grep foo file.txt || echo not found");
+    expect(r).toContain("rg");
+    expect(r).toContain("||");
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+});
+
+describe("passthrough — no change flag", () => {
+  it("returns changed:false when no grep", () => {
+    expect(changed("ls -la")).toBe(false);
+  });
+
+  it("returns changed:true when grep rewritten", () => {
+    expect(changed("grep pattern file.txt")).toBe(true);
+  });
+
+  it("returns changed:false for grep in non-initial position", () => {
+    expect(changed("echo grep")).toBe(false);
+  });
+});
+
+describe("BRE conversion via shell", () => {
+  it("BRE alternation: command rewritten to rg", () => {
+    // Input: grep with BRE pattern foo\|bar
+    // translateGrepArgs converts \| → | (ERE); quote() then shell-escapes | → \|
+    // Net: command is rewritten from grep to rg (the meaningful observable change)
+    const r = rewritten("grep 'foo\\|bar' file.txt");
+    expect(r).toMatch(/^rg/);
+    expect(r).not.toMatch(/\bgrep\b/);
+    expect(changed("grep 'foo\\|bar' file.txt")).toBe(true);
+  });
+});

--- a/packages/pi-reflag/src/shell.ts
+++ b/packages/pi-reflag/src/shell.ts
@@ -1,0 +1,95 @@
+import type { ControlOperator, ParseEntry } from "shell-quote";
+import { parse, quote } from "shell-quote";
+import { translateGrepArgs } from "./grep.js";
+
+type OpEntry = { op: ControlOperator } | { op: "glob"; pattern: string };
+
+function isOp(entry: ParseEntry): entry is OpEntry {
+  return typeof entry === "object" && "op" in entry;
+}
+
+function isString(entry: ParseEntry): entry is string {
+  return typeof entry === "string";
+}
+
+function isSubshell(entry: ParseEntry): boolean {
+  return isOp(entry) && (entry.op === "(" || entry.op === ")");
+}
+
+type Segment = {
+  tokens: string[];
+  trailingOp: ControlOperator | null;
+};
+
+function splitSegments(entries: ParseEntry[]): Segment[] | null {
+  const segments: Segment[] = [];
+  let current: string[] = [];
+
+  for (const entry of entries) {
+    if (isSubshell(entry)) {
+      return null;
+    }
+    if (isOp(entry)) {
+      const op = entry.op === "glob" ? null : entry.op;
+      if (op === null) {
+        return null;
+      }
+      segments.push({ tokens: current, trailingOp: op });
+      current = [];
+    } else if (isString(entry)) {
+      current.push(entry);
+    } else {
+      return null;
+    }
+  }
+  segments.push({ tokens: current, trailingOp: null });
+  return segments;
+}
+
+function rewriteSegment(tokens: string[]): { tokens: string[]; changed: boolean } {
+  if (tokens[0] !== "grep") {
+    return { tokens, changed: false };
+  }
+  const translated = translateGrepArgs(tokens.slice(1));
+  return { tokens: ["rg", ...translated], changed: true };
+}
+
+function joinSegments(segments: Segment[]): string {
+  const parts: string[] = [];
+  for (const { tokens, trailingOp } of segments) {
+    parts.push(quote(tokens));
+    if (trailingOp !== null) {
+      parts.push(trailingOp);
+    }
+  }
+  return parts.join(" ");
+}
+
+export function rewriteCommand(cmd: string): { rewritten: string; changed: boolean } {
+  let entries: ParseEntry[];
+  try {
+    entries = parse(cmd);
+  } catch {
+    return { rewritten: cmd, changed: false };
+  }
+
+  const segments = splitSegments(entries);
+  if (segments === null) {
+    return { rewritten: cmd, changed: false };
+  }
+
+  let anyChanged = false;
+  const rewritten = segments.map((seg) => {
+    const result = rewriteSegment(seg.tokens);
+    if (result.changed) {
+      anyChanged = true;
+    }
+    return { tokens: result.tokens, trailingOp: seg.trailingOp };
+  });
+
+  if (!anyChanged) {
+    return { rewritten: cmd, changed: false };
+  }
+
+  return { rewritten: joinSegments(rewritten), changed: true };
+}

--- a/packages/pi-reflag/tsconfig.json
+++ b/packages/pi-reflag/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,28 @@ importers:
         specifier: ^3.2.1
         version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
 
+  packages/pi-reflag:
+    dependencies:
+      shell-quote:
+        specifier: ^1.8.4
+        version: 1.8.4
+    devDependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@types/shell-quote':
+        specifier: ^1.7.5
+        version: 1.7.5
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
+
   packages/pi-sem:
     devDependencies:
       '@earendil-works/pi-agent-core':
@@ -857,6 +879,9 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
+  '@types/shell-quote@1.7.5':
+    resolution: {integrity: sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -1417,6 +1442,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2470,6 +2499,8 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@types/shell-quote@1.7.5': {}
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -3036,6 +3067,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.4: {}
 
   siginfo@2.0.0: {}
 


### PR DESCRIPTION
## Summary

Adds `pi-reflag` — a new pi extension that transparently rewrites `grep` commands to `rg` (ripgrep) before they execute.

## What it does

- Intercepts `bash` tool calls via `tool_call` event
- Rewrites `grep ...` (including piped commands) to `rg ...` with translated flags
- Shows a user-visible toast notification with `before → after` — agent never sees it
- Skips commands with subshells to avoid misinterpreting nested commands
- Controlled by `--pi-reflag-grep` flag (`on` by default, `off` to disable)

## Flag translation

- Drops `-r`/`-R`/`-E`/`--recursive`/`--extended-regexp` (rg defaults)
- Maps long flags to rg short equivalents
- Converts `--include=`/`--exclude=`/`--exclude-dir=` to `-g` globs
- Converts BRE patterns to ERE when `-G`/`--basic-regexp` is used
- Passes through `-A`/`-B`/`-C`, `-i`/`-n`/`-v`/`-w`/`-l`/`-c`/`-o`/`-F`/`-P` unchanged

The argument translation logic is ported from [greprip-rs](https://github.com/kaofelix/greprip-rs) (MIT).