### PR TITLE
feat: pi-reflag — add find→fd rewriting + unknown flag fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,12 @@ Makes the agent respond in caveman mode — cuts ~75% of output tokens while kee
 Adds a `review-plan` tool that writes a named markdown plan to `~/.pi/plan/<repo>/<name>.md`, opens it in Zed, commits it to a git repo inside `~/.pi/plan/`, and shows an interactive terminal widget so the user can confirm, request changes, or reply freely before the agent proceeds.
 
 ### `pi-reflag` (`packages/pi-reflag`)
-Intercepts `bash` tool calls and rewrites `grep` commands to `rg` (ripgrep) transparently before execution. Handles flag translation (drops `-r`/`-R`/`-E`, maps long flags, converts `--include`/`--exclude` to `-g` globs, converts BRE patterns to ERE). Skips commands with subshells. Shows a user-visible toast notification on rewrite — agent never sees it. Controlled by the `pi-reflag-grep` flag (`on` by default, set to `off` to disable).
+Intercepts `bash` tool calls and rewrites `grep` → `rg` (ripgrep) and `find` → `fd` transparently before execution. Shows a user-visible toast notification on rewrite — agent never sees it.
+
+- **grep → rg**: drops `-r`/`-R`/`-E`, maps long flags, converts `--include`/`--exclude` to `-g` globs, converts BRE patterns to ERE. Controlled by `pi-reflag-grep` flag (`on` by default).
+- **find → fd**: translates `-name`/`-iname` to `-g` globs (OR patterns become brace expansion), `-type`, `-maxdepth`/`-mindepth`, `-exec`/`-execdir`, `-mtime`/`-size`/`-user`/`-group` and more. Always adds `-H` (fd excludes hidden files by default, find doesn’t). Controlled by `pi-reflag-find` flag (`on` by default).
+
+Skips commands with subshells. Both rewrites are independent — either can be disabled without affecting the other.
 
 ### `pi-sem` (`packages/pi-sem`) — private
 Wraps the [`sem`](https://github.com/piotr-oles/sem) CLI as four pi tools: `sem_context`, `sem_entities`, `sem_impact`, `sem_diff`. Gives the model semantic understanding of code structure without reading entire files.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A monorepo of [pi coding agent](https://github.com/earendil-works/pi) extensions
 | [`@piotr-oles/pi-fence`](packages/pi-fence) | Detects and handles decorative fence/divider comments in written code — warn, block, or auto-remove |
 | [`@piotr-oles/pi-caveman`](packages/pi-caveman) | Makes the agent respond in caveman mode — cuts ~75% of output tokens while keeping full technical accuracy |
 | [`@piotr-oles/pi-plan`](packages/pi-plan) | Adds a `plan` tool — saves a named markdown plan to disk, opens it for review, and waits for user confirmation before proceeding |
-| [`@piotr-oles/pi-reflag`](packages/pi-reflag) | Transparently rewrites `grep` commands to `rg` (ripgrep) before they execute — faster searches, zero agent behavior change |
+| [`@piotr-oles/pi-reflag`](packages/pi-reflag) | Transparently rewrites `grep` → `rg` (ripgrep) and `find` → `fd` before they execute — faster searches, zero agent behavior change |
 
 ## Development
 

--- a/packages/pi-reflag/README.md
+++ b/packages/pi-reflag/README.md
@@ -1,6 +1,6 @@
 # pi-reflag
 
-A [pi coding agent](https://github.com/earendil-works/pi) extension that transparently rewrites `grep` commands to [`rg`](https://github.com/BurntSushi/ripgrep) (ripgrep) before they execute — faster searches with zero agent behavior change.
+A [pi coding agent](https://github.com/earendil-works/pi) extension that transparently rewrites `grep` commands to [`rg`](https://github.com/BurntSushi/ripgrep) (ripgrep) and `find` commands to [`fd`](https://github.com/sharkdp/fd) before they execute — faster searches with zero agent behavior change.
 
 ## Install
 
@@ -8,16 +8,20 @@ A [pi coding agent](https://github.com/earendil-works/pi) extension that transpa
 pi install npm:@piotr-oles/pi-reflag
 ```
 
-Requires `rg` on `$PATH`. Install ripgrep via your package manager if needed:
+Requires `rg` and `fd` on `$PATH`:
 
 ```bash
-brew install ripgrep      # macOS
-apt install ripgrep       # Debian/Ubuntu
+brew install ripgrep fd      # macOS
+apt install ripgrep fd-find  # Debian/Ubuntu
 ```
 
 ## How it works
 
-Intercepts `bash` tool calls in the `tool_call` event. When the command starts with `grep` (including piped commands like `grep … | head`), it translates the arguments to their `rg` equivalents and rewrites the command in place before execution. The agent never sees the rewrite — only a user-visible toast notification is shown.
+Intercepts `bash` tool calls in the `tool_call` event. When a command segment starts with `grep` or `find` (including piped commands), it translates the arguments to their `rg`/`fd` equivalents and rewrites the command in place before execution. The agent never sees the rewrite — only a user-visible toast notification is shown.
+
+Subshell constructs (`$(…)`, `(…)`) are left untouched to avoid misinterpreting nested commands.
+
+## grep → rg
 
 **What gets translated:**
 
@@ -42,20 +46,60 @@ Intercepts `bash` tool calls in the `tool_call` event. When the command starts w
 | `-s` | `--no-messages` |
 | `-N` (numeric context) | `-C N` |
 
-Subshell constructs (`$(…)`, `(…)`) are left untouched to avoid misinterpreting nested commands.
-
-## Usage
-
-The extension is active by default. Disable it per-session with the `--pi-reflag-grep` flag:
+Disable per-session:
 
 ```bash
 pi --pi-reflag-grep off
 ```
 
+## find → fd
+
+**What gets translated:**
+
+| find expression | fd equivalent |
+|---|---|
+| (always) | `-H` added — fd excludes hidden files by default, find doesn't |
+| `-name <glob>` | `-g <glob>` |
+| `-iname <glob>` | `-i -g <glob>` |
+| `-name a -o -name b` | `-g {a,b}` (brace expansion) |
+| `! -name <glob>` / `-not -name <glob>` | `-E <glob>` |
+| `-type f/d/l` | `-t f/d/l` |
+| `-maxdepth N` | `-d N` |
+| `-mindepth N` | `--min-depth N` |
+| `-exec cmd {} \;` | `-x cmd {}` |
+| `-exec cmd {} +` | `-X cmd {}` |
+| `-print0` | `-0` |
+| `-print` | dropped (fd default) |
+| `-L` / `-follow` | `-L` |
+| `-path <pat> -prune` | `-E <pat>` (exclude directory) |
+| `-path <pat>` | `-p <pat>` (full-path match) |
+| `-regex <pat>` | `<pat>` (fd regex) |
+| `-iregex <pat>` | `-i <pat>` |
+| `-size <spec>` | `-S <spec>` |
+| `-newer <file>` | `--newer <file>` |
+| `-mtime`/`-atime`/`-ctime -N` | `--changed-within Nd` |
+| `-mtime`/`-atime`/`-ctime +N` | `--changed-before Nd` |
+| `-mmin`/`-amin`/`-cmin -N` | `--changed-within Nmin` |
+| `-mmin`/`-amin`/`-cmin +N` | `--changed-before Nmin` |
+| `-user <name>` | `--owner <name>` |
+| `-group <name>` | `--owner :<name>` |
+| `-empty` | `-t e` |
+| `-executable` | `-t x` |
+| `-xdev` / `-mount` | `--one-file-system` |
+| `-quit` | `-1` |
+
+Disable per-session:
+
+```bash
+pi --pi-reflag-find off
+```
+
 ## Thanks
 
-- [ripgrep](https://github.com/BurntSushi/ripgrep) by Andrew Gallant — the fast, modern grep replacement this extension routes to
-- [greprip-rs](https://github.com/kaofelix/greprip-rs) by kaofelix — the grep → rg argument translation logic is ported from that project (MIT)
+- [ripgrep](https://github.com/BurntSushi/ripgrep) by Andrew Gallant
+- [fd](https://github.com/sharkdp/fd) by David Peter
+- [greprip-rs](https://github.com/kaofelix/greprip-rs) by kaofelix — grep→rg and find→fd translation logic ported from this project (MIT)
+- [reflag](https://github.com/kluzzebass/reflag) by kluzzebass — additional find→fd flag mappings referenced from this project (MIT)
 
 ## Development
 

--- a/packages/pi-reflag/src/find.test.ts
+++ b/packages/pi-reflag/src/find.test.ts
@@ -8,7 +8,11 @@ import { describe, expect, it } from "vitest";
 import { translateFindArgs } from "./find.js";
 
 function t(args: string[]): string[] {
-  return translateFindArgs(args);
+  return translateFindArgs(args).args;
+}
+
+function unknowns(args: string[]): string[] {
+  return translateFindArgs(args).unknownFlags;
 }
 
 describe("hidden files", () => {
@@ -377,6 +381,10 @@ describe("misc flags", () => {
     expect(r).not.toContain("644");
   });
 
+  it("unknown flag not forwarded to output", () => {
+    expect(t([".", "-samefile", "other.txt"])).not.toContain("-samefile");
+  });
+
   it("logical operators (, ), -o, -a dropped", () => {
     const r = t([".", "(", "-name", "*.ts", "-o", "-name", "*.tsx", ")"]);
     expect(r).not.toContain("(");
@@ -433,11 +441,69 @@ describe("combined real-world patterns", () => {
     expect(r).toContain("wc");
   });
 
+  it("find . \\( -name '*.ts' -o -name '*.tsx' \\) -type f (parens + OR)", () => {
+    const r = t([".", "(", "-name", "*.ts", "-o", "-name", "*.tsx", ")", "-type", "f"]);
+    const gIdx = r.indexOf("-g");
+    expect(gIdx).toBeGreaterThan(-1);
+    expect(r[gIdx + 1]).toBe("{*.ts,*.tsx}");
+    expect(r).toContain("-t");
+  });
+
   it("find . -type f -name '*.log' -mtime +7 (old logs)", () => {
     const r = t([".", "-type", "f", "-name", "*.log", "-mtime", "+7"]);
     expect(r).toContain("-t");
     expect(r).toContain("--changed-before");
     expect(r).toContain("7d");
     expect(r).toContain("*.log");
+  });
+});
+
+describe("unknown flags", () => {
+  it("no unknowns for common expressions", () => {
+    expect(unknowns([".", "-name", "*.ts"])).toHaveLength(0);
+    expect(unknowns([".", "-type", "f", "-maxdepth", "2"])).toHaveLength(0);
+    expect(unknowns([".", "-exec", "wc", "{}", ";"])).toHaveLength(0);
+    expect(unknowns([".", "-mtime", "-7", "-size", "+1M"])).toHaveLength(0);
+  });
+
+  it("-samefile reported as unknown", () => {
+    expect(unknowns([".", "-samefile", "other.txt"])).toContain("-samefile");
+  });
+
+  it("-inum reported as unknown", () => {
+    expect(unknowns([".", "-inum", "12345"])).toContain("-inum");
+  });
+
+  it("-links reported as unknown", () => {
+    expect(unknowns([".", "-links", "2"])).toContain("-links");
+  });
+
+  it("-nouser reported as unknown", () => {
+    expect(unknowns([".", "-nouser"])).toContain("-nouser");
+  });
+
+  it("multiple unknowns all reported", () => {
+    const u = unknowns([".", "-samefile", "f", "-inum", "123"]);
+    expect(u).toContain("-samefile");
+    expect(u).toContain("-inum");
+  });
+
+  it("unknown flag not forwarded to translated args", () => {
+    const r = t([".", "-samefile", "other.txt", "-name", "*.ts"]);
+    expect(r).not.toContain("-samefile");
+    expect(r).toContain("*.ts");
+  });
+
+  it("logical operators not flagged as unknown", () => {
+    expect(unknowns([".", "(", "-name", "*.ts", "-o", "-name", "*.tsx", ")"])).toHaveLength(0);
+    expect(unknowns([".", "-name", "*.ts", "-a", "-type", "f"])).toHaveLength(0);
+  });
+
+  it("known-but-dropped expressions not flagged (-print, -prune, -depth)", () => {
+    expect(unknowns([".", "-print"])).toHaveLength(0);
+    expect(unknowns([".", "-prune"])).toHaveLength(0);
+    expect(unknowns([".", "-depth"])).toHaveLength(0);
+    expect(unknowns([".", "-daystart"])).toHaveLength(0);
+    expect(unknowns([".", "-delete"])).toHaveLength(0);
   });
 });

--- a/packages/pi-reflag/src/find.test.ts
+++ b/packages/pi-reflag/src/find.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Tests for find→fd argument translation.
+ * Cases ported from:
+ *   - kaofelix/greprip-rs tests/test_find_to_fd.rs
+ *   - kluzzebass/reflag translator/find2fd/translator_test.go
+ */
+import { describe, expect, it } from "vitest";
+import { translateFindArgs } from "./find.js";
+
+function t(args: string[]): string[] {
+  return translateFindArgs(args);
+}
+
+describe("hidden files", () => {
+  it("always adds -H to match find default", () => {
+    expect(t([".", "-name", "*.ts"])).toContain("-H");
+  });
+
+  it("adds -H even with no args", () => {
+    expect(t([])).toContain("-H");
+  });
+});
+
+describe("path handling", () => {
+  it("skips . (fd defaults to current dir)", () => {
+    const r = t([".", "-name", "*.ts"]);
+    // Only -H itself should precede flags; no bare . in output
+    const dotPositions = r.flatMap((x, idx) => (x === "." ? [idx] : []));
+    // If . appears, it must be the match-all pattern before a path, not a duplicate
+    // Since we have a pattern via -g, there should be no bare .
+    expect(dotPositions).toHaveLength(0);
+  });
+
+  it("passes through specific path", () => {
+    const r = t(["/some/path", "-name", "*.ts"]);
+    expect(r).toContain("/some/path");
+  });
+
+  it("passes through multiple paths", () => {
+    const r = t(["/tmp", "/var/tmp", "-type", "f"]);
+    expect(r).toContain("/tmp");
+    expect(r).toContain("/var/tmp");
+  });
+
+  it("path comes after pattern in output", () => {
+    const r = t(["/some/path", "-name", "*.ts"]);
+    const gIdx = r.indexOf("-g");
+    const pathIdx = r.indexOf("/some/path");
+    expect(gIdx).toBeGreaterThan(-1);
+    expect(pathIdx).toBeGreaterThan(gIdx + 1);
+  });
+
+  it("adds . match-all pattern when path present but no name filter", () => {
+    const r = t(["/tmp", "-type", "f"]);
+    const dotIdx = r.indexOf(".");
+    const pathIdx = r.indexOf("/tmp");
+    expect(dotIdx).toBeGreaterThan(-1);
+    expect(pathIdx).toBeGreaterThan(dotIdx);
+  });
+
+  it("no match-all . added when no explicit path and no pattern", () => {
+    const r = t([".", "-type", "f"]);
+    expect(r).not.toContain(".");
+  });
+});
+
+describe("-name patterns", () => {
+  it("single -name → -g glob", () => {
+    const r = t([".", "-name", "*.ts"]);
+    const gIdx = r.indexOf("-g");
+    expect(gIdx).toBeGreaterThan(-1);
+    expect(r[gIdx + 1]).toBe("*.ts");
+  });
+
+  it("-name exact filename", () => {
+    const r = t([".", "-name", "Makefile"]);
+    expect(r).toContain("-g");
+    expect(r).toContain("Makefile");
+  });
+
+  it("-name compound extension", () => {
+    const r = t([".", "-name", "*.tar.gz"]);
+    expect(r).toContain("-g");
+    expect(r).toContain("*.tar.gz");
+  });
+
+  it("multiple -name OR'd → brace expansion", () => {
+    const r = t([".", "-name", "*.ts", "-o", "-name", "*.tsx"]);
+    const gIdx = r.indexOf("-g");
+    expect(gIdx).toBeGreaterThan(-1);
+    expect(r[gIdx + 1]).toBe("{*.ts,*.tsx}");
+  });
+
+  it("three -name patterns OR'd", () => {
+    const r = t([".", "-name", ".ruby-version", "-o", "-name", ".tool-versions", "-o", "-name", "mise.toml"]);
+    const gIdx = r.indexOf("-g");
+    expect(gIdx).toBeGreaterThan(-1);
+    expect(r[gIdx + 1]).toBe("{.ruby-version,.tool-versions,mise.toml}");
+  });
+
+  it("-iname → -i flag + -g glob", () => {
+    const r = t([".", "-iname", "*.TXT"]);
+    expect(r).toContain("-i");
+    expect(r).toContain("-g");
+    expect(r).toContain("*.TXT");
+  });
+
+  it("-iname positions -i before pattern", () => {
+    const r = t([".", "-iname", "readme*"]);
+    const iIdx = r.indexOf("-i");
+    const gIdx = r.indexOf("-g");
+    expect(iIdx).toBeGreaterThan(-1);
+    expect(gIdx).toBeGreaterThan(iIdx);
+  });
+});
+
+describe("negation", () => {
+  it("! -name PAT → -E PAT", () => {
+    const r = t([".", "!", "-name", "*.pyc"]);
+    expect(r).toContain("-E");
+    expect(r).toContain("*.pyc");
+  });
+
+  it("-not -name PAT → -E PAT", () => {
+    const r = t([".", "-not", "-name", "*.pyc"]);
+    expect(r).toContain("-E");
+    expect(r).toContain("*.pyc");
+  });
+});
+
+describe("type filter", () => {
+  it("-type f → -t f", () => {
+    const r = t([".", "-type", "f"]);
+    expect(r).toContain("-t");
+    expect(r[r.indexOf("-t") + 1]).toBe("f");
+  });
+
+  it("-type d → -t d", () => {
+    const r = t([".", "-type", "d"]);
+    expect(r).toContain("-t");
+    expect(r[r.indexOf("-t") + 1]).toBe("d");
+  });
+
+  it("-type l → -t l", () => {
+    const r = t([".", "-type", "l"]);
+    expect(r).toContain("-t");
+    expect(r[r.indexOf("-t") + 1]).toBe("l");
+  });
+});
+
+describe("depth", () => {
+  it("-maxdepth N → -d N", () => {
+    const r = t([".", "-maxdepth", "2"]);
+    expect(r).toContain("-d");
+    expect(r[r.indexOf("-d") + 1]).toBe("2");
+  });
+
+  it("-mindepth N → --min-depth N", () => {
+    const r = t([".", "-mindepth", "1"]);
+    expect(r).toContain("--min-depth");
+    expect(r[r.indexOf("--min-depth") + 1]).toBe("1");
+  });
+
+  it("both -mindepth and -maxdepth", () => {
+    const r = t([".", "-mindepth", "2", "-maxdepth", "4"]);
+    expect(r).toContain("--min-depth");
+    expect(r).toContain("-d");
+    expect(r[r.indexOf("--min-depth") + 1]).toBe("2");
+    expect(r[r.indexOf("-d") + 1]).toBe("4");
+  });
+});
+
+describe("exec", () => {
+  it("-exec cmd {} ; → -x cmd {}", () => {
+    const r = t([".", "-name", "*.py", "-exec", "wc", "-l", "{}", ";"]);
+    expect(r).toContain("-x");
+    expect(r).toContain("wc");
+    expect(r).toContain("-l");
+    expect(r).toContain("{}");
+  });
+
+  it("-exec cmd {} + → -X cmd {}", () => {
+    const r = t([".", "-type", "f", "-exec", "chmod", "644", "{}", "+"]);
+    expect(r).toContain("-X");
+    expect(r).toContain("chmod");
+    expect(r).toContain("644");
+  });
+
+  it("exec args come after paths", () => {
+    const r = t(["/path", "-name", "*.ts", "-exec", "cat", "{}", ";"]);
+    const pathIdx = r.indexOf("/path");
+    const xIdx = r.indexOf("-x");
+    expect(xIdx).toBeGreaterThan(pathIdx);
+  });
+
+  it("-execdir treated same as -exec", () => {
+    const r = t([".", "-execdir", "echo", "{}", ";"]);
+    expect(r).toContain("-x");
+    expect(r).toContain("echo");
+  });
+});
+
+describe("output flags", () => {
+  it("-print0 → -0", () => {
+    expect(t([".", "-name", "*.txt", "-print0"])).toContain("-0");
+  });
+
+  it("-print is dropped", () => {
+    const r = t([".", "-name", "*.txt", "-print"]);
+    expect(r).not.toContain("-print");
+  });
+});
+
+describe("symlink flags", () => {
+  it("-L before path → -L in output", () => {
+    const r = t(["-L", ".", "-name", "*.txt"]);
+    expect(r).toContain("-L");
+  });
+
+  it("-follow → -L", () => {
+    const r = t(["-follow", ".", "-name", "*.txt"]);
+    expect(r).toContain("-L");
+  });
+
+  it("-L in expression position → -L", () => {
+    const r = t([".", "-L", "-name", "*.txt"]);
+    expect(r).toContain("-L");
+  });
+});
+
+describe("time filters", () => {
+  it("-mtime -7 → --changed-within 7d", () => {
+    const r = t([".", "-mtime", "-7"]);
+    expect(r).toContain("--changed-within");
+    expect(r[r.indexOf("--changed-within") + 1]).toBe("7d");
+  });
+
+  it("-mtime +30 → --changed-before 30d", () => {
+    const r = t([".", "-mtime", "+30"]);
+    expect(r).toContain("--changed-before");
+    expect(r[r.indexOf("--changed-before") + 1]).toBe("30d");
+  });
+
+  it("-atime -1 → --changed-within 1d", () => {
+    const r = t([".", "-atime", "-1"]);
+    expect(r).toContain("--changed-within");
+    expect(r[r.indexOf("--changed-within") + 1]).toBe("1d");
+  });
+
+  it("-ctime +7 → --changed-before 7d", () => {
+    const r = t([".", "-ctime", "+7"]);
+    expect(r).toContain("--changed-before");
+    expect(r[r.indexOf("--changed-before") + 1]).toBe("7d");
+  });
+
+  it("-mmin -60 → --changed-within 60min", () => {
+    const r = t([".", "-mmin", "-60"]);
+    expect(r).toContain("--changed-within");
+    expect(r[r.indexOf("--changed-within") + 1]).toBe("60min");
+  });
+
+  it("-amin +30 → --changed-before 30min", () => {
+    const r = t([".", "-amin", "+30"]);
+    expect(r).toContain("--changed-before");
+    expect(r[r.indexOf("--changed-before") + 1]).toBe("30min");
+  });
+});
+
+describe("size", () => {
+  it("-size +1M → -S +1M", () => {
+    const r = t([".", "-size", "+1M"]);
+    expect(r).toContain("-S");
+    expect(r[r.indexOf("-S") + 1]).toBe("+1M");
+  });
+
+  it("-size +100M", () => {
+    const r = t([".", "-type", "f", "-size", "+100M"]);
+    expect(r).toContain("-S");
+    expect(r[r.indexOf("-S") + 1]).toBe("+100M");
+  });
+});
+
+describe("newer", () => {
+  it("-newer file → --newer file", () => {
+    const r = t([".", "-newer", "go.mod"]);
+    expect(r).toContain("--newer");
+    expect(r[r.indexOf("--newer") + 1]).toBe("go.mod");
+  });
+});
+
+describe("user and group", () => {
+  it("-user root → --owner root", () => {
+    const r = t([".", "-user", "root"]);
+    expect(r).toContain("--owner");
+    expect(r[r.indexOf("--owner") + 1]).toBe("root");
+  });
+
+  it("-group wheel → --owner :wheel", () => {
+    const r = t([".", "-group", "wheel"]);
+    expect(r).toContain("--owner");
+    expect(r[r.indexOf("--owner") + 1]).toBe(":wheel");
+  });
+});
+
+describe("-path expression", () => {
+  it("-path PAT -prune → -E with stripped pattern", () => {
+    const r = t([".", "-path", "*/.git", "-prune"]);
+    expect(r).toContain("-E");
+    expect(r[r.indexOf("-E") + 1]).toBe(".git");
+  });
+
+  it("-path PAT without -prune → -p PAT", () => {
+    const r = t([".", "-path", "*/test/*"]);
+    expect(r).toContain("-p");
+    expect(r[r.indexOf("-p") + 1]).toBe("*/test/*");
+  });
+});
+
+describe("regex patterns", () => {
+  it("-regex PAT → pattern without -g", () => {
+    const r = t([".", "-regex", ".*\\.go$"]);
+    expect(r).toContain(".*\\.go$");
+    expect(r).not.toContain("-g");
+  });
+
+  it("-iregex PAT → -i + pattern without -g", () => {
+    const r = t([".", "-iregex", ".*\\.GO$"]);
+    expect(r).toContain("-i");
+    expect(r).toContain(".*\\.GO$");
+    expect(r).not.toContain("-g");
+  });
+
+  it("-name takes priority over -regex", () => {
+    const r = t([".", "-name", "*.ts", "-regex", ".*\\.go$"]);
+    expect(r).toContain("-g");
+    expect(r).toContain("*.ts");
+    expect(r).not.toContain(".*\\.go$");
+  });
+});
+
+describe("misc flags", () => {
+  it("-empty → -t e", () => {
+    const r = t([".", "-empty"]);
+    expect(r).toContain("-t");
+    expect(r[r.indexOf("-t") + 1]).toBe("e");
+  });
+
+  it("-executable → -t x", () => {
+    const r = t([".", "-executable"]);
+    expect(r).toContain("-t");
+    expect(r[r.indexOf("-t") + 1]).toBe("x");
+  });
+
+  it("-xdev → --one-file-system", () => {
+    expect(t([".", "-xdev"])).toContain("--one-file-system");
+  });
+
+  it("-mount → --one-file-system", () => {
+    expect(t([".", "-mount"])).toContain("--one-file-system");
+  });
+
+  it("-quit → -1", () => {
+    expect(t([".", "-name", "*.go", "-quit"])).toContain("-1");
+  });
+
+  it("-print dropped", () => {
+    expect(t([".", "-print"])).not.toContain("-print");
+  });
+
+  it("-prune dropped", () => {
+    expect(t([".", "-prune"])).not.toContain("-prune");
+  });
+
+  it("-perm silently dropped (no fd equivalent)", () => {
+    const r = t([".", "-perm", "644"]);
+    expect(r).not.toContain("-perm");
+    expect(r).not.toContain("644");
+  });
+
+  it("logical operators (, ), -o, -a dropped", () => {
+    const r = t([".", "(", "-name", "*.ts", "-o", "-name", "*.tsx", ")"]);
+    expect(r).not.toContain("(");
+    expect(r).not.toContain(")");
+    expect(r).not.toContain("-o");
+  });
+});
+
+describe("combined real-world patterns", () => {
+  it("find . -type f -name '*.ts'", () => {
+    const r = t([".", "-type", "f", "-name", "*.ts"]);
+    expect(r).toContain("-H");
+    expect(r).toContain("-t");
+    expect(r[r.indexOf("-t") + 1]).toBe("f");
+    expect(r).toContain("-g");
+    expect(r).toContain("*.ts");
+  });
+
+  it("find . -type d -name node_modules", () => {
+    const r = t([".", "-type", "d", "-name", "node_modules"]);
+    expect(r).toContain("-t");
+    expect(r[r.indexOf("-t") + 1]).toBe("d");
+    expect(r).toContain("node_modules");
+  });
+
+  it("find . -maxdepth 2 -name '*.json'", () => {
+    const r = t([".", "-maxdepth", "2", "-name", "*.json"]);
+    expect(r).toContain("-d");
+    expect(r[r.indexOf("-d") + 1]).toBe("2");
+    expect(r).toContain("*.json");
+  });
+
+  it("find /var/log -name '*.log' -mtime -1", () => {
+    const r = t(["/var/log", "-name", "*.log", "-mtime", "-1"]);
+    expect(r).toContain("--changed-within");
+    expect(r).toContain("1d");
+    expect(r).toContain("*.log");
+    expect(r).toContain("/var/log");
+  });
+
+  it("find /path -maxdepth 3 -name a -o -name b", () => {
+    const r = t(["/path", "-maxdepth", "3", "-name", ".ruby-version", "-o", "-name", ".tool-versions"]);
+    expect(r).toContain("/path");
+    expect(r).toContain("-d");
+    const gIdx = r.indexOf("-g");
+    expect(gIdx).toBeGreaterThan(-1);
+    expect(r[gIdx + 1]).toBe("{.ruby-version,.tool-versions}");
+  });
+
+  it("find . \\( -type f \\) -exec wc {} + (parens + batch exec)", () => {
+    const r = t([".", "(", "-type", "f", ")", "-exec", "wc", "{}", "+"]);
+    expect(r).toContain("-t");
+    expect(r).toContain("-X");
+    expect(r).toContain("wc");
+  });
+
+  it("find . -type f -name '*.log' -mtime +7 (old logs)", () => {
+    const r = t([".", "-type", "f", "-name", "*.log", "-mtime", "+7"]);
+    expect(r).toContain("-t");
+    expect(r).toContain("--changed-before");
+    expect(r).toContain("7d");
+    expect(r).toContain("*.log");
+  });
+});

--- a/packages/pi-reflag/src/find.test.ts
+++ b/packages/pi-reflag/src/find.test.ts
@@ -96,7 +96,17 @@ describe("-name patterns", () => {
   });
 
   it("three -name patterns OR'd", () => {
-    const r = t([".", "-name", ".ruby-version", "-o", "-name", ".tool-versions", "-o", "-name", "mise.toml"]);
+    const r = t([
+      ".",
+      "-name",
+      ".ruby-version",
+      "-o",
+      "-name",
+      ".tool-versions",
+      "-o",
+      "-name",
+      "mise.toml",
+    ]);
     const gIdx = r.indexOf("-g");
     expect(gIdx).toBeGreaterThan(-1);
     expect(r[gIdx + 1]).toBe("{.ruby-version,.tool-versions,mise.toml}");
@@ -426,7 +436,16 @@ describe("combined real-world patterns", () => {
   });
 
   it("find /path -maxdepth 3 -name a -o -name b", () => {
-    const r = t(["/path", "-maxdepth", "3", "-name", ".ruby-version", "-o", "-name", ".tool-versions"]);
+    const r = t([
+      "/path",
+      "-maxdepth",
+      "3",
+      "-name",
+      ".ruby-version",
+      "-o",
+      "-name",
+      ".tool-versions",
+    ]);
     expect(r).toContain("/path");
     expect(r).toContain("-d");
     const gIdx = r.indexOf("-g");

--- a/packages/pi-reflag/src/find.ts
+++ b/packages/pi-reflag/src/find.ts
@@ -7,14 +7,22 @@
  */
 
 function translateDays(val: string): string[] {
-  if (val.startsWith("-")) return ["--changed-within", `${val.slice(1)}d`];
-  if (val.startsWith("+")) return ["--changed-before", `${val.slice(1)}d`];
+  if (val.startsWith("-")) {
+    return ["--changed-within", `${val.slice(1)}d`];
+  }
+  if (val.startsWith("+")) {
+    return ["--changed-before", `${val.slice(1)}d`];
+  }
   return ["--changed-within", `${val}d`];
 }
 
 function translateMins(val: string): string[] {
-  if (val.startsWith("-")) return ["--changed-within", `${val.slice(1)}min`];
-  if (val.startsWith("+")) return ["--changed-before", `${val.slice(1)}min`];
+  if (val.startsWith("-")) {
+    return ["--changed-within", `${val.slice(1)}min`];
+  }
+  if (val.startsWith("+")) {
+    return ["--changed-before", `${val.slice(1)}min`];
+  }
   return ["--changed-within", `${val}min`];
 }
 
@@ -64,7 +72,14 @@ export function translateFindArgs(args: string[]): { args: string[]; unknownFlag
   while (i < args.length) {
     const arg = args[i];
 
-    if (arg === "(" || arg === ")" || arg === "-o" || arg === "-or" || arg === "-a" || arg === "-and") {
+    if (
+      arg === "(" ||
+      arg === ")" ||
+      arg === "-o" ||
+      arg === "-or" ||
+      arg === "-a" ||
+      arg === "-and"
+    ) {
       i++;
       continue;
     }
@@ -167,7 +182,9 @@ export function translateFindArgs(args: string[]): { args: string[]; unknownFlag
         const pat = args[i + 1].replace(/^\*\//, "").replace(/\/\*$/, "").replace(/\*$/, "");
         result.push("-E", pat);
         i += 3;
-        if (i < args.length && (args[i] === "-o" || args[i] === "-or")) i++;
+        if (i < args.length && (args[i] === "-o" || args[i] === "-or")) {
+          i++;
+        }
       } else {
         result.push("-p", args[i + 1]);
         i += 2;
@@ -202,15 +219,48 @@ export function translateFindArgs(args: string[]): { args: string[]; unknownFlag
       continue;
     }
 
-    if (arg === "-print0") { result.push("-0"); i++; continue; }
-    if (arg === "-print") { i++; continue; }
-    if (arg === "-L" || arg === "-follow") { result.push("-L"); i++; continue; }
-    if (arg === "-H" || arg === "-P") { i++; continue; }
-    if (arg === "-empty") { result.push("-t", "e"); i++; continue; }
-    if (arg === "-executable") { result.push("-t", "x"); i++; continue; }
-    if (arg === "-xdev" || arg === "-mount") { result.push("--one-file-system"); i++; continue; }
-    if (arg === "-quit") { result.push("-1"); i++; continue; }
-    if (arg === "-prune" || arg === "-depth" || arg === "-daystart" || arg === "-delete") { i++; continue; }
+    if (arg === "-print0") {
+      result.push("-0");
+      i++;
+      continue;
+    }
+    if (arg === "-print") {
+      i++;
+      continue;
+    }
+    if (arg === "-L" || arg === "-follow") {
+      result.push("-L");
+      i++;
+      continue;
+    }
+    if (arg === "-H" || arg === "-P") {
+      i++;
+      continue;
+    }
+    if (arg === "-empty") {
+      result.push("-t", "e");
+      i++;
+      continue;
+    }
+    if (arg === "-executable") {
+      result.push("-t", "x");
+      i++;
+      continue;
+    }
+    if (arg === "-xdev" || arg === "-mount") {
+      result.push("--one-file-system");
+      i++;
+      continue;
+    }
+    if (arg === "-quit") {
+      result.push("-1");
+      i++;
+      continue;
+    }
+    if (arg === "-prune" || arg === "-depth" || arg === "-daystart" || arg === "-delete") {
+      i++;
+      continue;
+    }
 
     // unknown expression
     if (arg.startsWith("-")) {

--- a/packages/pi-reflag/src/find.ts
+++ b/packages/pi-reflag/src/find.ts
@@ -1,0 +1,238 @@
+/**
+ * Translate find command-line arguments to fd equivalents.
+ *
+ * Ported from:
+ *   - kaofelix/greprip-rs src/fnd.rs (MIT)
+ *   - kluzzebass/reflag translator/find2fd/translator.go (MIT)
+ */
+
+function translateDays(val: string): string[] {
+  if (val.startsWith("-")) return ["--changed-within", `${val.slice(1)}d`];
+  if (val.startsWith("+")) return ["--changed-before", `${val.slice(1)}d`];
+  return ["--changed-within", `${val}d`];
+}
+
+function translateMins(val: string): string[] {
+  if (val.startsWith("-")) return ["--changed-within", `${val.slice(1)}min`];
+  if (val.startsWith("+")) return ["--changed-before", `${val.slice(1)}min`];
+  return ["--changed-within", `${val}min`];
+}
+
+export function translateFindArgs(args: string[]): string[] {
+  const result: string[] = [];
+  const paths: string[] = [];
+  const globPatterns: string[] = [];
+  let regexPattern: string | null = null;
+  const execArgs: string[] = [];
+  let caseInsensitive = false;
+
+  // fd excludes hidden files by default; find includes them
+  result.push("-H");
+
+  let i = 0;
+
+  // Phase 1: leading find-level options before path args (-L, -H, -P)
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === "-L" || arg === "-follow") {
+      result.push("-L");
+      i++;
+    } else if (arg === "-H" || arg === "-P") {
+      // -H (find) = follow command-line symlinks; already added fd's -H above
+      // -P = no symlink follow (fd default)
+      i++;
+    } else {
+      break;
+    }
+  }
+
+  // Phase 2: collect path arguments (stop at first expression)
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg.startsWith("-") || arg === "!" || arg === "(" || arg === ")") {
+      break;
+    }
+    // skip "." — fd defaults to current directory
+    if (arg !== ".") {
+      paths.push(arg);
+    }
+    i++;
+  }
+
+  // Phase 3: process expressions
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "(" || arg === ")" || arg === "-o" || arg === "-or" || arg === "-a" || arg === "-and") {
+      i++;
+      continue;
+    }
+
+    // ! -name PAT or -not -name PAT → exclude pattern
+    if ((arg === "!" || arg === "-not") && i + 2 < args.length && args[i + 1] === "-name") {
+      result.push("-E", args[i + 2]);
+      i += 3;
+      continue;
+    }
+
+    if (arg === "!" || arg === "-not") {
+      i++;
+      continue;
+    }
+
+    if (arg === "-name" && i + 1 < args.length) {
+      globPatterns.push(args[i + 1]);
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-iname" && i + 1 < args.length) {
+      caseInsensitive = true;
+      globPatterns.push(args[i + 1]);
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-regex" && i + 1 < args.length) {
+      regexPattern = args[i + 1];
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-iregex" && i + 1 < args.length) {
+      caseInsensitive = true;
+      regexPattern = args[i + 1];
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-type" && i + 1 < args.length) {
+      result.push("-t", args[i + 1]);
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-maxdepth" && i + 1 < args.length) {
+      result.push("-d", args[i + 1]);
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-mindepth" && i + 1 < args.length) {
+      result.push("--min-depth", args[i + 1]);
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-size" && i + 1 < args.length) {
+      result.push("-S", args[i + 1]);
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-newer" && i + 1 < args.length) {
+      result.push("--newer", args[i + 1]);
+      i += 2;
+      continue;
+    }
+
+    if ((arg === "-mtime" || arg === "-atime" || arg === "-ctime") && i + 1 < args.length) {
+      result.push(...translateDays(args[i + 1]));
+      i += 2;
+      continue;
+    }
+
+    if ((arg === "-mmin" || arg === "-amin" || arg === "-cmin") && i + 1 < args.length) {
+      result.push(...translateMins(args[i + 1]));
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-user" && i + 1 < args.length) {
+      result.push("--owner", args[i + 1]);
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-group" && i + 1 < args.length) {
+      result.push("--owner", `:${args[i + 1]}`);
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-path" && i + 1 < args.length) {
+      if (i + 2 < args.length && args[i + 2] === "-prune") {
+        // -path PAT -prune → exclude directory: strip leading */ and trailing /*
+        const pat = args[i + 1].replace(/^\*\//, "").replace(/\/\*$/, "").replace(/\*$/, "");
+        result.push("-E", pat);
+        i += 3;
+        if (i < args.length && (args[i] === "-o" || args[i] === "-or")) i++;
+      } else {
+        result.push("-p", args[i + 1]);
+        i += 2;
+      }
+      continue;
+    }
+
+    if (arg === "-perm" && i + 1 < args.length) {
+      // no fd equivalent
+      i += 2;
+      continue;
+    }
+
+    if (arg === "-exec" || arg === "-execdir") {
+      const cmdArgs: string[] = [];
+      i++;
+      let batchMode = false;
+      while (i < args.length) {
+        if (args[i] === ";" || args[i] === "\\;") {
+          i++;
+          break;
+        }
+        if (args[i] === "+") {
+          batchMode = true;
+          i++;
+          break;
+        }
+        cmdArgs.push(args[i]);
+        i++;
+      }
+      execArgs.push(batchMode ? "-X" : "-x", ...cmdArgs);
+      continue;
+    }
+
+    if (arg === "-print0") { result.push("-0"); i++; continue; }
+    if (arg === "-print") { i++; continue; }
+    if (arg === "-L" || arg === "-follow") { result.push("-L"); i++; continue; }
+    if (arg === "-H" || arg === "-P") { i++; continue; }
+    if (arg === "-empty") { result.push("-t", "e"); i++; continue; }
+    if (arg === "-executable") { result.push("-t", "x"); i++; continue; }
+    if (arg === "-xdev" || arg === "-mount") { result.push("--one-file-system"); i++; continue; }
+    if (arg === "-quit") { result.push("-1"); i++; continue; }
+    if (arg === "-prune" || arg === "-depth" || arg === "-daystart" || arg === "-delete") { i++; continue; }
+
+    // unknown: skip
+    i++;
+  }
+
+  if (caseInsensitive) {
+    result.push("-i");
+  }
+
+  // glob patterns take priority over regex pattern
+  if (globPatterns.length === 1) {
+    result.push("-g", globPatterns[0]);
+  } else if (globPatterns.length > 1) {
+    result.push("-g", `{${globPatterns.join(",")}}`);
+  } else if (regexPattern !== null) {
+    result.push(regexPattern);
+  } else if (paths.length > 0) {
+    // fd requires a pattern before path args; "." matches everything
+    result.push(".");
+  }
+
+  result.push(...paths);
+  result.push(...execArgs);
+
+  return result;
+}

--- a/packages/pi-reflag/src/find.ts
+++ b/packages/pi-reflag/src/find.ts
@@ -18,8 +18,9 @@ function translateMins(val: string): string[] {
   return ["--changed-within", `${val}min`];
 }
 
-export function translateFindArgs(args: string[]): string[] {
+export function translateFindArgs(args: string[]): { args: string[]; unknownFlags: string[] } {
   const result: string[] = [];
+  const unknownFlags: string[] = [];
   const paths: string[] = [];
   const globPatterns: string[] = [];
   let regexPattern: string | null = null;
@@ -211,7 +212,10 @@ export function translateFindArgs(args: string[]): string[] {
     if (arg === "-quit") { result.push("-1"); i++; continue; }
     if (arg === "-prune" || arg === "-depth" || arg === "-daystart" || arg === "-delete") { i++; continue; }
 
-    // unknown: skip
+    // unknown expression
+    if (arg.startsWith("-")) {
+      unknownFlags.push(arg);
+    }
     i++;
   }
 
@@ -234,5 +238,5 @@ export function translateFindArgs(args: string[]): string[] {
   result.push(...paths);
   result.push(...execArgs);
 
-  return result;
+  return { args: result, unknownFlags };
 }

--- a/packages/pi-reflag/src/grep.test.ts
+++ b/packages/pi-reflag/src/grep.test.ts
@@ -370,7 +370,9 @@ describe("unknown flags", () => {
 
   it("unknown long option reported", () => {
     expect(unknowns(["--binary-files=text", "hello", "file.txt"])).toContain("--binary-files=text");
-    expect(unknowns(["--context-separator=--", "hello", "file.txt"])).toContain("--context-separator=--");
+    expect(unknowns(["--context-separator=--", "hello", "file.txt"])).toContain(
+      "--context-separator=--",
+    );
   });
 
   it("-- end-of-options marker not flagged as unknown", () => {

--- a/packages/pi-reflag/src/grep.test.ts
+++ b/packages/pi-reflag/src/grep.test.ts
@@ -8,7 +8,11 @@ import { describe, expect, it } from "vitest";
 import { translateGrepArgs } from "./grep.js";
 
 function t(args: string[]): string[] {
-  return translateGrepArgs(args);
+  return translateGrepArgs(args).args;
+}
+
+function unknowns(args: string[]): string[] {
+  return translateGrepArgs(args).unknownFlags;
 }
 
 describe("basic patterns", () => {
@@ -261,9 +265,9 @@ describe("long options", () => {
     expect(result.join(" ")).toMatch(/-H|--with-filename/);
   });
 
-  it("unknown long option passed through", () => {
-    const result = t(["--some-unknown-flag", "hello", "file.txt"]);
-    expect(result).toContain("--some-unknown-flag");
+  it("unknown long option detected, not passed through", () => {
+    expect(unknowns(["--some-unknown-flag", "hello", "file.txt"])).toContain("--some-unknown-flag");
+    expect(t(["--some-unknown-flag", "hello", "file.txt"])).not.toContain("--some-unknown-flag");
   });
 });
 
@@ -353,5 +357,48 @@ describe("fixed strings skip BRE conversion", () => {
     const result = t(["-F", "-e", "foo\\|bar", "file.txt"]);
     expect(result).toContain("foo\\|bar");
     expect(result).not.toContain("foo|bar");
+  });
+});
+
+describe("unknown flags", () => {
+  it("no unknowns for common flags", () => {
+    expect(unknowns(["-r", "-n", "hello", "file.txt"])).toHaveLength(0);
+    expect(unknowns(["-i", "hello", "file.txt"])).toHaveLength(0);
+    expect(unknowns(["--ignore-case", "hello", "file.txt"])).toHaveLength(0);
+    expect(unknowns(["--include=*.ts", "-r", "hello", "dir/"])).toHaveLength(0);
+  });
+
+  it("unknown long option reported", () => {
+    expect(unknowns(["--binary-files=text", "hello", "file.txt"])).toContain("--binary-files=text");
+    expect(unknowns(["--context-separator=--", "hello", "file.txt"])).toContain("--context-separator=--");
+  });
+
+  it("-- end-of-options marker not flagged as unknown", () => {
+    expect(unknowns(["--", "hello", "file.txt"])).toHaveLength(0);
+  });
+
+  it("unknown standalone short flag reported", () => {
+    expect(unknowns(["-x", "hello", "file.txt"])).toContain("-x");
+    expect(unknowns(["-Z", "hello", "file.txt"])).toContain("-Z");
+  });
+
+  it("unknown char in combined short flag reported", () => {
+    expect(unknowns(["-rx", "hello", "dir/"])).toContain("-x");
+  });
+
+  it("known chars in combined flag produce no unknowns", () => {
+    expect(unknowns(["-rni", "hello", "dir/"])).toHaveLength(0);
+    expect(unknowns(["-rl", "hello", "dir/"])).toHaveLength(0);
+  });
+
+  it("multiple unknown flags all reported", () => {
+    const u = unknowns(["--foo", "--bar", "hello"]);
+    expect(u).toContain("--foo");
+    expect(u).toContain("--bar");
+  });
+
+  it("unknown flag excluded from translated args", () => {
+    expect(t(["-x", "hello", "file.txt"])).not.toContain("-x");
+    expect(t(["--foo", "hello", "file.txt"])).not.toContain("--foo");
   });
 });

--- a/packages/pi-reflag/src/grep.ts
+++ b/packages/pi-reflag/src/grep.ts
@@ -71,9 +71,10 @@ const LONG_TO_SHORT: ReadonlyMap<string, string | null> = new Map([
   ["--recursive", null],
 ]);
 
-export function translateGrepArgs(args: string[]): string[] {
+export function translateGrepArgs(args: string[]): { args: string[]; unknownFlags: string[] } {
   const fixedStrings = hasFixedStringsFlag(args);
   const result: string[] = [];
+  const unknownFlags: string[] = [];
   let i = 0;
   let patternSeen = false;
 
@@ -135,6 +136,11 @@ export function translateGrepArgs(args: string[]): string[] {
     }
 
     if (arg.startsWith("--")) {
+      if (arg === "--") {
+        result.push(arg);
+        i++;
+        continue;
+      }
       if (DROP_LONG.has(arg)) {
         i++;
         continue;
@@ -147,7 +153,12 @@ export function translateGrepArgs(args: string[]): string[] {
         i++;
         continue;
       }
-      result.push(arg);
+      if (PASSTHROUGH_NO_ARG.has(arg)) {
+        result.push(arg);
+        i++;
+        continue;
+      }
+      unknownFlags.push(arg);
       i++;
       continue;
     }
@@ -155,14 +166,10 @@ export function translateGrepArgs(args: string[]): string[] {
     if (arg.startsWith("-") && arg.length > 2 && !/^-\d/.test(arg)) {
       for (const c of arg.slice(1)) {
         const flag = `-${c}`;
-        if (DROP_SHORT.has(flag)) {
-          continue;
-        }
-        if (flag === "-s") {
-          result.push("--no-messages");
-          continue;
-        }
-        result.push(flag);
+        if (DROP_SHORT.has(flag)) continue;
+        if (flag === "-s") { result.push("--no-messages"); continue; }
+        if (PASSTHROUGH_NO_ARG.has(flag)) { result.push(flag); continue; }
+        unknownFlags.push(flag);
       }
       i++;
       continue;
@@ -194,6 +201,12 @@ export function translateGrepArgs(args: string[]): string[] {
       continue;
     }
 
+    if (arg.startsWith("-") && arg.length > 1) {
+      unknownFlags.push(arg);
+      i++;
+      continue;
+    }
+
     if (!patternSeen) {
       result.push(fixedStrings ? arg : convertBreToEre(arg));
       patternSeen = true;
@@ -203,5 +216,5 @@ export function translateGrepArgs(args: string[]): string[] {
     i++;
   }
 
-  return result;
+  return { args: result, unknownFlags };
 }

--- a/packages/pi-reflag/src/grep.ts
+++ b/packages/pi-reflag/src/grep.ts
@@ -166,9 +166,17 @@ export function translateGrepArgs(args: string[]): { args: string[]; unknownFlag
     if (arg.startsWith("-") && arg.length > 2 && !/^-\d/.test(arg)) {
       for (const c of arg.slice(1)) {
         const flag = `-${c}`;
-        if (DROP_SHORT.has(flag)) continue;
-        if (flag === "-s") { result.push("--no-messages"); continue; }
-        if (PASSTHROUGH_NO_ARG.has(flag)) { result.push(flag); continue; }
+        if (DROP_SHORT.has(flag)) {
+          continue;
+        }
+        if (flag === "-s") {
+          result.push("--no-messages");
+          continue;
+        }
+        if (PASSTHROUGH_NO_ARG.has(flag)) {
+          result.push(flag);
+          continue;
+        }
         unknownFlags.push(flag);
       }
       i++;

--- a/packages/pi-reflag/src/index.ts
+++ b/packages/pi-reflag/src/index.ts
@@ -7,16 +7,24 @@ export default function piReflag(pi: ExtensionAPI): void {
     description: "grep → rg rewriting: on (default) or off",
   });
 
+  pi.registerFlag("pi-reflag-find", {
+    type: "string",
+    description: "find → fd rewriting: on (default) or off",
+  });
+
   pi.on("tool_call", async (event, ctx) => {
     if (!isToolCallEventType("bash", event)) {
       return undefined;
     }
-    if (pi.getFlag("pi-reflag-grep") === "off") {
+
+    const rewriteGrep = pi.getFlag("pi-reflag-grep") !== "off";
+    const rewriteFind = pi.getFlag("pi-reflag-find") !== "off";
+    if (!rewriteGrep && !rewriteFind) {
       return undefined;
     }
 
     const original = event.input.command;
-    const { rewritten, changed } = rewriteCommand(original);
+    const { rewritten, changed } = rewriteCommand(original, { rewriteGrep, rewriteFind });
     if (!changed) {
       return undefined;
     }

--- a/packages/pi-reflag/src/index.ts
+++ b/packages/pi-reflag/src/index.ts
@@ -24,7 +24,13 @@ export default function piReflag(pi: ExtensionAPI): void {
     }
 
     const original = event.input.command;
-    const { rewritten, changed } = rewriteCommand(original, { rewriteGrep, rewriteFind });
+    const { rewritten, changed, unknownFlags } = rewriteCommand(original, { rewriteGrep, rewriteFind });
+
+    if (unknownFlags.length > 0) {
+      const flags = unknownFlags.map((f) => `\`${f}\``).join(", ");
+      ctx.ui.notify(`pi-reflag: unknown flag ${flags} — kept original command`, "warning");
+    }
+
     if (!changed) {
       return undefined;
     }

--- a/packages/pi-reflag/src/index.ts
+++ b/packages/pi-reflag/src/index.ts
@@ -24,7 +24,10 @@ export default function piReflag(pi: ExtensionAPI): void {
     }
 
     const original = event.input.command;
-    const { rewritten, changed, unknownFlags } = rewriteCommand(original, { rewriteGrep, rewriteFind });
+    const { rewritten, changed, unknownFlags } = rewriteCommand(original, {
+      rewriteGrep,
+      rewriteFind,
+    });
 
     if (unknownFlags.length > 0) {
       const flags = unknownFlags.map((f) => `\`${f}\``).join(", ");

--- a/packages/pi-reflag/src/shell.test.ts
+++ b/packages/pi-reflag/src/shell.test.ts
@@ -9,6 +9,14 @@ function changed(cmd: string): boolean {
   return rewriteCommand(cmd).changed;
 }
 
+function rewrittenOpts(cmd: string, opts: { rewriteGrep?: boolean; rewriteFind?: boolean }): string {
+  return rewriteCommand(cmd, opts).rewritten;
+}
+
+function changedOpts(cmd: string, opts: { rewriteGrep?: boolean; rewriteFind?: boolean }): boolean {
+  return rewriteCommand(cmd, opts).changed;
+}
+
 describe("no grep — unchanged", () => {
   it("no grep at all", () => {
     expect(changed("echo hello")).toBe(false);
@@ -124,6 +132,99 @@ describe("passthrough — no change flag", () => {
 
   it("returns changed:false for grep in non-initial position", () => {
     expect(changed("echo grep")).toBe(false);
+  });
+});
+
+describe("no find — unchanged", () => {
+  it("no find at all", () => {
+    expect(changed("echo hello")).toBe(false);
+  });
+
+  it("find in non-initial position", () => {
+    expect(changed("echo find")).toBe(false);
+  });
+
+  it("absolute path find untouched", () => {
+    expect(changed("/usr/bin/find . -name '*.ts'")).toBe(false);
+  });
+
+  it("fd command untouched", () => {
+    expect(changed("fd '*.ts' src/")).toBe(false);
+  });
+});
+
+describe("simple find rewrites", () => {
+  it("find . -name rewrites to fd", () => {
+    const r = rewritten("find . -name '*.ts'");
+    expect(r).toContain("fd");
+    expect(r).toContain("*.ts");
+    expect(r).not.toMatch(/\bfind\b/);
+  });
+
+  it("find with path", () => {
+    const r = rewritten("find packages/ -name 'index.ts'");
+    expect(r).toContain("fd");
+    expect(r).toContain("packages/");
+    expect(r).not.toMatch(/\bfind\b/);
+  });
+
+  it("-maxdepth translated", () => {
+    const r = rewritten("find . -maxdepth 2 -name '*.json'");
+    expect(r).toContain("fd");
+    expect(r).toContain("-d");
+    expect(r).toContain("2");
+    expect(changed("find . -maxdepth 2 -name '*.json'")).toBe(true);
+  });
+
+  it("-type f kept", () => {
+    const r = rewritten("find . -type f -name '*.ts'");
+    expect(r).toContain("-t");
+    expect(r).toContain("f");
+    expect(r).not.toMatch(/\bfind\b/);
+  });
+});
+
+describe("find pipeline rewrites", () => {
+  it("find piped to another command", () => {
+    const r = rewritten("find . -name '*.ts' | xargs wc -l");
+    expect(r).toContain("fd");
+    expect(r).toContain("|");
+    expect(r).toContain("xargs");
+    expect(r).not.toMatch(/\bfind\b/);
+  });
+
+  it("grep and find both in pipeline rewritten", () => {
+    const r = rewritten("find . -name '*.ts' | grep import");
+    expect(r).toContain("fd");
+    expect(r).toContain("rg");
+    expect(r).not.toMatch(/\bfind\b/);
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+});
+
+describe("rewriteCommand options", () => {
+  it("rewriteGrep:false skips grep", () => {
+    const r = rewrittenOpts("grep hello file.txt", { rewriteGrep: false });
+    expect(r).toMatch(/\bgrep\b/);
+    expect(changedOpts("grep hello file.txt", { rewriteGrep: false })).toBe(false);
+  });
+
+  it("rewriteFind:false skips find", () => {
+    const r = rewrittenOpts("find . -name '*.ts'", { rewriteFind: false });
+    expect(r).toMatch(/\bfind\b/);
+    expect(changedOpts("find . -name '*.ts'", { rewriteFind: false })).toBe(false);
+  });
+
+  it("rewriteFind:false still rewrites grep", () => {
+    const r = rewrittenOpts("grep hello file.txt", { rewriteFind: false });
+    expect(r).toContain("rg");
+    expect(r).not.toMatch(/\bgrep\b/);
+  });
+
+  it("rewriteGrep:false still rewrites find", () => {
+    const r = rewrittenOpts("find . -name '*.ts'", { rewriteGrep: false });
+    expect(r).toContain("fd");
+    expect(r).not.toMatch(/\bfind\b/);
   });
 });
 

--- a/packages/pi-reflag/src/shell.test.ts
+++ b/packages/pi-reflag/src/shell.test.ts
@@ -17,6 +17,10 @@ function changedOpts(cmd: string, opts: { rewriteGrep?: boolean; rewriteFind?: b
   return rewriteCommand(cmd, opts).changed;
 }
 
+function unknownFlagsOf(cmd: string): string[] {
+  return rewriteCommand(cmd).unknownFlags;
+}
+
 describe("no grep — unchanged", () => {
   it("no grep at all", () => {
     expect(changed("echo hello")).toBe(false);
@@ -225,6 +229,60 @@ describe("rewriteCommand options", () => {
     const r = rewrittenOpts("find . -name '*.ts'", { rewriteGrep: false });
     expect(r).toContain("fd");
     expect(r).not.toMatch(/\bfind\b/);
+  });
+});
+
+describe("unknown flag fallback", () => {
+  it("unknown grep long flag → not rewritten, unknown reported", () => {
+    expect(changed("grep --binary-files=text hello file.txt")).toBe(false);
+    expect(unknownFlagsOf("grep --binary-files=text hello file.txt")).toContain("--binary-files=text");
+  });
+
+  it("unknown grep short flag → not rewritten, unknown reported", () => {
+    expect(changed("grep -x hello file.txt")).toBe(false);
+    expect(unknownFlagsOf("grep -x hello file.txt")).toContain("-x");
+  });
+
+  it("unknown find flag → not rewritten, unknown reported", () => {
+    expect(changed("find . -samefile other.txt")).toBe(false);
+    expect(unknownFlagsOf("find . -samefile other.txt")).toContain("-samefile");
+  });
+
+  it("unknown find flag → not rewritten, unknown reported", () => {
+    expect(changed("find . -inum 12345")).toBe(false);
+    expect(unknownFlagsOf("find . -inum 12345")).toContain("-inum");
+  });
+
+  it("known-only grep → still rewritten, no unknowns", () => {
+    expect(changed("grep -rn hello src/")).toBe(true);
+    expect(unknownFlagsOf("grep -rn hello src/")).toHaveLength(0);
+  });
+
+  it("known-only find → still rewritten, no unknowns", () => {
+    expect(changed("find . -type f -name '*.ts'")).toBe(true);
+    expect(unknownFlagsOf("find . -type f -name '*.ts'")).toHaveLength(0);
+  });
+
+  it("pipeline: grep unknown falls back, find known still rewrites", () => {
+    const r = rewritten("find . -name '*.ts' | grep --binary-files=text import");
+    expect(r).toContain("fd");
+    expect(r).not.toMatch(/\bfind\b/);
+    expect(r).toMatch(/\bgrep\b/);
+    expect(r).not.toContain("rg");
+    expect(unknownFlagsOf("find . -name '*.ts' | grep --binary-files=text import")).toContain("--binary-files=text");
+  });
+
+  it("pipeline: find unknown falls back, grep known still rewrites", () => {
+    const r = rewritten("find . -samefile other | grep pattern");
+    expect(r).toMatch(/\bfind\b/);
+    expect(r).toContain("rg");
+    expect(r).not.toMatch(/\bgrep\b/);
+    expect(unknownFlagsOf("find . -samefile other | grep pattern")).toContain("-samefile");
+  });
+
+  it("no unknowns when no grep/find", () => {
+    expect(unknownFlagsOf("echo hello")).toHaveLength(0);
+    expect(unknownFlagsOf("ls -la")).toHaveLength(0);
   });
 });
 

--- a/packages/pi-reflag/src/shell.test.ts
+++ b/packages/pi-reflag/src/shell.test.ts
@@ -9,7 +9,10 @@ function changed(cmd: string): boolean {
   return rewriteCommand(cmd).changed;
 }
 
-function rewrittenOpts(cmd: string, opts: { rewriteGrep?: boolean; rewriteFind?: boolean }): string {
+function rewrittenOpts(
+  cmd: string,
+  opts: { rewriteGrep?: boolean; rewriteFind?: boolean },
+): string {
   return rewriteCommand(cmd, opts).rewritten;
 }
 
@@ -235,7 +238,9 @@ describe("rewriteCommand options", () => {
 describe("unknown flag fallback", () => {
   it("unknown grep long flag → not rewritten, unknown reported", () => {
     expect(changed("grep --binary-files=text hello file.txt")).toBe(false);
-    expect(unknownFlagsOf("grep --binary-files=text hello file.txt")).toContain("--binary-files=text");
+    expect(unknownFlagsOf("grep --binary-files=text hello file.txt")).toContain(
+      "--binary-files=text",
+    );
   });
 
   it("unknown grep short flag → not rewritten, unknown reported", () => {
@@ -269,7 +274,9 @@ describe("unknown flag fallback", () => {
     expect(r).not.toMatch(/\bfind\b/);
     expect(r).toMatch(/\bgrep\b/);
     expect(r).not.toContain("rg");
-    expect(unknownFlagsOf("find . -name '*.ts' | grep --binary-files=text import")).toContain("--binary-files=text");
+    expect(unknownFlagsOf("find . -name '*.ts' | grep --binary-files=text import")).toContain(
+      "--binary-files=text",
+    );
   });
 
   it("pipeline: find unknown falls back, grep known still rewrites", () => {

--- a/packages/pi-reflag/src/shell.ts
+++ b/packages/pi-reflag/src/shell.ts
@@ -54,12 +54,16 @@ function rewriteSegment(
 ): { tokens: string[]; changed: boolean; unknownFlags: string[] } {
   if (rewriteGrep && tokens[0] === "grep") {
     const { args, unknownFlags } = translateGrepArgs(tokens.slice(1));
-    if (unknownFlags.length > 0) return { tokens, changed: false, unknownFlags };
+    if (unknownFlags.length > 0) {
+      return { tokens, changed: false, unknownFlags };
+    }
     return { tokens: ["rg", ...args], changed: true, unknownFlags: [] };
   }
   if (rewriteFind && tokens[0] === "find") {
     const { args, unknownFlags } = translateFindArgs(tokens.slice(1));
-    if (unknownFlags.length > 0) return { tokens, changed: false, unknownFlags };
+    if (unknownFlags.length > 0) {
+      return { tokens, changed: false, unknownFlags };
+    }
     return { tokens: ["fd", ...args], changed: true, unknownFlags: [] };
   }
   return { tokens, changed: false, unknownFlags: [] };
@@ -96,7 +100,9 @@ export function rewriteCommand(
   const allUnknownFlags: string[] = [];
   const rewritten = segments.map((seg) => {
     const result = rewriteSegment(seg.tokens, rewriteGrep, rewriteFind);
-    if (result.changed) anyChanged = true;
+    if (result.changed) {
+      anyChanged = true;
+    }
     allUnknownFlags.push(...result.unknownFlags);
     return { tokens: result.tokens, trailingOp: seg.trailingOp };
   });

--- a/packages/pi-reflag/src/shell.ts
+++ b/packages/pi-reflag/src/shell.ts
@@ -1,5 +1,6 @@
 import type { ControlOperator, ParseEntry } from "shell-quote";
 import { parse, quote } from "shell-quote";
+import { translateFindArgs } from "./find.js";
 import { translateGrepArgs } from "./grep.js";
 
 type OpEntry = { op: ControlOperator } | { op: "glob"; pattern: string };
@@ -46,12 +47,18 @@ function splitSegments(entries: ParseEntry[]): Segment[] | null {
   return segments;
 }
 
-function rewriteSegment(tokens: string[]): { tokens: string[]; changed: boolean } {
-  if (tokens[0] !== "grep") {
-    return { tokens, changed: false };
+function rewriteSegment(
+  tokens: string[],
+  rewriteGrep: boolean,
+  rewriteFind: boolean,
+): { tokens: string[]; changed: boolean } {
+  if (rewriteGrep && tokens[0] === "grep") {
+    return { tokens: ["rg", ...translateGrepArgs(tokens.slice(1))], changed: true };
   }
-  const translated = translateGrepArgs(tokens.slice(1));
-  return { tokens: ["rg", ...translated], changed: true };
+  if (rewriteFind && tokens[0] === "find") {
+    return { tokens: ["fd", ...translateFindArgs(tokens.slice(1))], changed: true };
+  }
+  return { tokens, changed: false };
 }
 
 function joinSegments(segments: Segment[]): string {
@@ -65,7 +72,10 @@ function joinSegments(segments: Segment[]): string {
   return parts.join(" ");
 }
 
-export function rewriteCommand(cmd: string): { rewritten: string; changed: boolean } {
+export function rewriteCommand(
+  cmd: string,
+  { rewriteGrep = true, rewriteFind = true }: { rewriteGrep?: boolean; rewriteFind?: boolean } = {},
+): { rewritten: string; changed: boolean } {
   let entries: ParseEntry[];
   try {
     entries = parse(cmd);
@@ -80,7 +90,7 @@ export function rewriteCommand(cmd: string): { rewritten: string; changed: boole
 
   let anyChanged = false;
   const rewritten = segments.map((seg) => {
-    const result = rewriteSegment(seg.tokens);
+    const result = rewriteSegment(seg.tokens, rewriteGrep, rewriteFind);
     if (result.changed) {
       anyChanged = true;
     }

--- a/packages/pi-reflag/src/shell.ts
+++ b/packages/pi-reflag/src/shell.ts
@@ -51,14 +51,18 @@ function rewriteSegment(
   tokens: string[],
   rewriteGrep: boolean,
   rewriteFind: boolean,
-): { tokens: string[]; changed: boolean } {
+): { tokens: string[]; changed: boolean; unknownFlags: string[] } {
   if (rewriteGrep && tokens[0] === "grep") {
-    return { tokens: ["rg", ...translateGrepArgs(tokens.slice(1))], changed: true };
+    const { args, unknownFlags } = translateGrepArgs(tokens.slice(1));
+    if (unknownFlags.length > 0) return { tokens, changed: false, unknownFlags };
+    return { tokens: ["rg", ...args], changed: true, unknownFlags: [] };
   }
   if (rewriteFind && tokens[0] === "find") {
-    return { tokens: ["fd", ...translateFindArgs(tokens.slice(1))], changed: true };
+    const { args, unknownFlags } = translateFindArgs(tokens.slice(1));
+    if (unknownFlags.length > 0) return { tokens, changed: false, unknownFlags };
+    return { tokens: ["fd", ...args], changed: true, unknownFlags: [] };
   }
-  return { tokens, changed: false };
+  return { tokens, changed: false, unknownFlags: [] };
 }
 
 function joinSegments(segments: Segment[]): string {
@@ -75,31 +79,31 @@ function joinSegments(segments: Segment[]): string {
 export function rewriteCommand(
   cmd: string,
   { rewriteGrep = true, rewriteFind = true }: { rewriteGrep?: boolean; rewriteFind?: boolean } = {},
-): { rewritten: string; changed: boolean } {
+): { rewritten: string; changed: boolean; unknownFlags: string[] } {
   let entries: ParseEntry[];
   try {
     entries = parse(cmd);
   } catch {
-    return { rewritten: cmd, changed: false };
+    return { rewritten: cmd, changed: false, unknownFlags: [] };
   }
 
   const segments = splitSegments(entries);
   if (segments === null) {
-    return { rewritten: cmd, changed: false };
+    return { rewritten: cmd, changed: false, unknownFlags: [] };
   }
 
   let anyChanged = false;
+  const allUnknownFlags: string[] = [];
   const rewritten = segments.map((seg) => {
     const result = rewriteSegment(seg.tokens, rewriteGrep, rewriteFind);
-    if (result.changed) {
-      anyChanged = true;
-    }
+    if (result.changed) anyChanged = true;
+    allUnknownFlags.push(...result.unknownFlags);
     return { tokens: result.tokens, trailingOp: seg.trailingOp };
   });
 
   if (!anyChanged) {
-    return { rewritten: cmd, changed: false };
+    return { rewritten: cmd, changed: false, unknownFlags: allUnknownFlags };
   }
 
-  return { rewritten: joinSegments(rewritten), changed: true };
+  return { rewritten: joinSegments(rewritten), changed: true, unknownFlags: allUnknownFlags };
 }


### PR DESCRIPTION
## Summary

Expands `pi-reflag` in two ways:

### 1. `find` → `fd` rewriting

Intercepts `bash` tool calls where a command segment starts with `find` and transparently rewrites it to `fd` before execution — same pattern as the existing `grep` → `rg` rewrite.

**Flag mappings:**
- `-name` / `-iname` → `-g` glob (`-i` for case-insensitive)
- Multiple `-name … -o -name …` → brace expansion `-g {a,b}`
- `! -name` / `-not -name` → `-E` (exclude)
- `-type`, `-maxdepth` / `-mindepth`, `-size`, `-newer`
- `-mtime` / `-atime` / `-ctime` → `--changed-within` / `--changed-before`
- `-mmin` / `-amin` / `-cmin` → same with `min` suffix
- `-user` / `-group` → `--owner`
- `-exec {} ;` → `-x`, `-exec {} +` → `-X`
- `-L` / `-follow`, `-print0`, `-empty`, `-executable`, `-xdev`, `-quit`, `-path`, `-regex`
- Always adds `-H` (fd excludes hidden files by default; find doesn't)
- Controlled by new `pi-reflag-find` flag (`on` by default)

Translation logic ported from [greprip-rs](https://github.com/kaofelix/greprip-rs) `src/fnd.rs` with additional flag coverage from [reflag](https://github.com/kluzzebass/reflag) `translator/find2fd/`.

### 2. Unknown flag fallback

Previously, unrecognised flags were silently dropped (find) or passed through (grep), which could produce wrong results silently.

Now:
- `translateGrepArgs` and `translateFindArgs` return `{ args, unknownFlags }` instead of `string[]`
- If any `unknownFlags` are present, the segment is **not rewritten** — original command kept
- A **warning toast** is shown: `pi-reflag: unknown flag `--foo` — kept original command`
- Per-segment: if one segment in a pipeline falls back, others still rewrite

Covers: unknown long options (`--binary-files=text`), unknown short flags (`-x`, `-Z`), unknown chars in combined flags (`-rx`), unknown find expressions (`-samefile`, `-inum`).

## Files

| File | Change |
|------|--------|
| `src/find.ts` | New — `translateFindArgs()` |
| `src/find.test.ts` | New — 75 tests |
| `src/grep.ts` | Unknown flag detection, new return type |
| `src/grep.test.ts` | Updated helper, 8 new unknown-flag tests |
| `src/shell.ts` | Propagates `unknownFlags`, per-segment fallback |
| `src/shell.test.ts` | 9 new fallback + mixed-pipeline tests |
| `src/index.ts` | `pi-reflag-find` flag, warning toast |
| `README.md`, `AGENTS.md`, `packages/pi-reflag/README.md` | Updated docs |

## Tests

188 tests total, all passing.