### PR TITLE
fix(pi-reflag): support xargs grep/find rewrites

### DIFF
--- a/packages/pi-reflag/src/find.ts
+++ b/packages/pi-reflag/src/find.ts
@@ -6,18 +6,16 @@
  *   - kluzzebass/reflag translator/find2fd/translator.go (MIT)
  */
 import type { CommandRewrite } from "./types.js";
+import { xargs } from "./xargs.js";
 
-export const find: CommandRewrite = {
-  isMatching(command) {
-    return command.name === "find";
-  },
-  rewrite(command) {
+export const find: CommandRewrite = xargs((command) => {
+  if (command.name === "find") {
     const args = translateFindArgs(command.args);
     if (args) {
       return { name: "fd", args };
     }
-  },
-};
+  }
+});
 
 function translateDays(val: string): string[] {
   if (val.startsWith("-")) {

--- a/packages/pi-reflag/src/grep.ts
+++ b/packages/pi-reflag/src/grep.ts
@@ -5,19 +5,16 @@
  */
 
 import type { CommandRewrite } from "./types.js";
+import { xargs } from "./xargs.js";
 
-export const grep: CommandRewrite = {
-  isMatching(command) {
-    return command.name === "grep";
-  },
-  rewrite(command) {
+export const grep: CommandRewrite = xargs((command) => {
+  if (command.name === "grep") {
     const args = translateGrepArgs(command.args);
-
     if (args) {
       return { name: "rg", args };
     }
-  },
-};
+  }
+});
 
 function convertBreToEre(pattern: string): string {
   return pattern

--- a/packages/pi-reflag/src/shell.test.ts
+++ b/packages/pi-reflag/src/shell.test.ts
@@ -209,6 +209,22 @@ describe("redirect handling", () => {
   });
 });
 
+describe("xargs grep rewrites", () => {
+  it("xargs grep basic", async () => {
+    expect(await rewriteBash("xargs grep -l pattern")).toEqual("xargs rg -l pattern");
+  });
+
+  it("find piped to xargs grep", async () => {
+    expect(await rewriteBash("find . -name '*.ts' | xargs grep -l 'tool_call'")).toEqual(
+      "fd -H -g '*.ts' | xargs rg -l 'tool_call'",
+    );
+  });
+
+  it("xargs grep with recursive flag dropped", async () => {
+    expect(await rewriteBash("xargs grep -rn pattern")).toEqual("xargs rg -n pattern");
+  });
+});
+
 describe("BRE conversion via shell", () => {
   it("BRE alternation: \\| converted to | within original shell quoting", async () => {
     expect(await rewriteBash("grep 'foo\\|bar' file.txt")).toEqual("rg 'foo|bar' file.txt");

--- a/packages/pi-reflag/src/shell.ts
+++ b/packages/pi-reflag/src/shell.ts
@@ -24,27 +24,24 @@ export async function rewriteBash(bash: string): Promise<string> {
     return bash;
   }
 
-  let rewrittenBash = bash;
+  let newBash = bash;
 
   for (const command of extractCommands(tree.rootNode)) {
-    const commandRewrite = COMMAND_REWRITES.find((r) => r.isMatching(command));
-    if (!commandRewrite) {
-      continue;
-    }
+    for (const rewrite of COMMAND_REWRITES) {
+      const newCommand = rewrite(command);
 
-    const rewrittenCommand = commandRewrite.rewrite(command);
-
-    if (rewrittenCommand) {
-      rewrittenBash =
-        rewrittenBash.slice(0, command.startIndex) +
-        stringifyCommand(rewrittenCommand) +
-        rewrittenBash.slice(command.endIndex);
+      if (newCommand) {
+        newBash =
+          newBash.slice(0, command.startIndex) +
+          stringifyCommand(newCommand) +
+          newBash.slice(command.endIndex);
+        break;
+      }
     }
   }
-
   tree.delete();
 
-  return rewrittenBash;
+  return newBash;
 }
 
 const COMPLEX_ARG_TYPES = new Set([

--- a/packages/pi-reflag/src/types.ts
+++ b/packages/pi-reflag/src/types.ts
@@ -3,7 +3,4 @@ export interface Command {
   args: string[];
 }
 
-export interface CommandRewrite {
-  isMatching(command: Command): boolean;
-  rewrite(command: Command): Command | undefined;
-}
+export type CommandRewrite = (command: Command) => Command | undefined;

--- a/packages/pi-reflag/src/xargs.test.ts
+++ b/packages/pi-reflag/src/xargs.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { xargs } from "./xargs.js";
+
+const xargsGrep = xargs((command) => {
+  if (command.name === "grep") {
+    return { name: "rg", args: command.args };
+  }
+});
+
+describe("xargs HOF — direct command", () => {
+  it("rewrites matching direct command", () => {
+    expect(xargsGrep({ name: "grep", args: ["-l", "pattern"] })).toEqual({
+      name: "rg",
+      args: ["-l", "pattern"],
+    });
+  });
+
+  it("returns undefined for non-matching direct command", () => {
+    expect(xargsGrep({ name: "find", args: ["."] })).toBeUndefined();
+  });
+
+  it("passes args unchanged", () => {
+    expect(xargsGrep({ name: "grep", args: ["-r", "-n", "foo", "src/"] })).toEqual({
+      name: "rg",
+      args: ["-r", "-n", "foo", "src/"],
+    });
+  });
+});
+
+describe("xargs HOF — xargs prefix", () => {
+  it("rewrites xargs matching-command", () => {
+    expect(xargsGrep({ name: "xargs", args: ["grep", "-l", "pattern"] })).toEqual({
+      name: "xargs",
+      args: ["rg", "-l", "pattern"],
+    });
+  });
+
+  it("preserves xargs name in output", () => {
+    const result = xargsGrep({ name: "xargs", args: ["grep", "foo"] });
+    expect(result?.name).toBe("xargs");
+  });
+
+  it("returns undefined for xargs non-matching-command", () => {
+    expect(xargsGrep({ name: "xargs", args: ["find", "."] })).toBeUndefined();
+  });
+
+  it("returns undefined for bare xargs with no subcommand", () => {
+    expect(xargsGrep({ name: "xargs", args: [] })).toBeUndefined();
+  });
+
+  it("forwards all subcommand args", () => {
+    expect(xargsGrep({ name: "xargs", args: ["grep", "-r", "-n", "foo", "src/"] })).toEqual({
+      name: "xargs",
+      args: ["rg", "-r", "-n", "foo", "src/"],
+    });
+  });
+});
+
+describe("xargs HOF — unrelated commands untouched", () => {
+  it("ignores echo", () => {
+    expect(xargsGrep({ name: "echo", args: ["hello"] })).toBeUndefined();
+  });
+
+  it("ignores xargs echo", () => {
+    expect(xargsGrep({ name: "xargs", args: ["echo", "hello"] })).toBeUndefined();
+  });
+});

--- a/packages/pi-reflag/src/xargs.ts
+++ b/packages/pi-reflag/src/xargs.ts
@@ -1,0 +1,19 @@
+import type { CommandRewrite } from "./types.js";
+
+/**
+ * Higher-order command rewrite to handle xargs case
+ * @param rewrite Basic command rewrite
+ * @returns Command rewrite that supports xargs
+ */
+export function xargs(rewrite: CommandRewrite): CommandRewrite {
+  return function rewriteXargs(command) {
+    if (command.name === "xargs" && typeof command.args[0] === "string") {
+      const result = rewrite({ name: command.args[0], args: command.args.slice(1) });
+      if (result) {
+        return { name: "xargs", args: [result.name, ...result.args] };
+      }
+      return undefined;
+    }
+    return rewrite(command);
+  };
+}


### PR DESCRIPTION
## Problem

`find . -name '*.ts' | xargs grep -l 'pattern'` — only `find` was rewritten, `xargs grep` was silently skipped.

**Root cause**: `grep.isMatching` checked `command.name === "grep"`. In a pipeline, tree-sitter sees `xargs grep ...` as `name = "xargs", args = ["grep", ...]` — never matched.

## Solution

Introduce `xargs(rewrite)` HOF in `xargs.ts` that wraps any `CommandRewrite` to also handle the `xargs <cmd>` prefix, re-wrapping the result back with `xargs`. Both `grep` and `find` rewrites are now wrapped with it.

**Bug fixed in HOF itself**: initial implementation returned inner rewrite result directly, dropping the `xargs` name. Fixed to re-wrap: `{ name: 'xargs', args: [result.name, ...result.args] }`.

## Changes

- `xargs.ts` — new HOF
- `xargs.test.ts` — 10 unit tests (direct command, xargs prefix, edge cases)
- `grep.ts` / `find.ts` — wrapped with `xargs()`
- `shell.test.ts` — added integration tests for `xargs grep` in pipeline