### PR TITLE
fix(pi-plan): throw on missing plan file and non-interactive mode

### DIFF
--- a/packages/pi-plan/src/plan-tool.test.ts
+++ b/packages/pi-plan/src/plan-tool.test.ts
@@ -53,20 +53,19 @@ function makeCtx(customReturnValue: unknown) {
 }
 
 describe("createReviewPlanTool - no UI", () => {
-  it("returns cancel with error message when hasUI is false", async () => {
+  it("throws when hasUI is false", async () => {
     const { ctx, custom } = makeCtx(null);
     const tool = createReviewPlanTool(testExec, "/nonexistent");
 
-    const result = await tool.execute(
-      "id",
-      { planPath: "repo/plan.md" },
-      AbortSignal.timeout(5000),
-      undefined,
-      ctx as any,
-    );
-
-    expect(textContent(result)).toContain("Error: UI not available");
-    expect(result.details.result).toBe("cancel");
+    await expect(
+      tool.execute(
+        "id",
+        { planPath: "repo/plan.md" },
+        AbortSignal.timeout(5000),
+        undefined,
+        ctx as any,
+      ),
+    ).rejects.toThrow("UI not available");
     expect(custom).not.toHaveBeenCalled();
   });
 });
@@ -82,6 +81,22 @@ describe("createReviewPlanTool - execute with UI", () => {
 
   afterEach(async () => {
     await rm(plansDir, { recursive: true, force: true });
+  });
+
+  it("throws when plan file does not exist", async () => {
+    const { ctx, custom } = makeCtx({ type: "cancel" });
+    const tool = createReviewPlanTool(testExec, plansDir);
+
+    await expect(
+      tool.execute(
+        "id",
+        { planPath: "my-repo/nonexistent.md" },
+        AbortSignal.timeout(5000),
+        undefined,
+        ctx as any,
+      ),
+    ).rejects.toThrow("Plan file not found");
+    expect(custom).not.toHaveBeenCalled();
   });
 
   it("returns cancel when user cancels", async () => {

--- a/packages/pi-plan/src/plan-tool.ts
+++ b/packages/pi-plan/src/plan-tool.ts
@@ -1,3 +1,4 @@
+import { access } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import type { ExtensionAPI, Theme, ToolDefinition } from "@earendil-works/pi-coding-agent";
@@ -42,15 +43,21 @@ export function createReviewPlanTool(
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       if (!ctx.hasUI) {
-        return {
-          content: [{ type: "text", text: "Error: UI not available in non-interactive mode." }],
-          details: { result: "cancel" },
-        };
+        throw new Error("UI not available in non-interactive mode.");
       }
 
       const planPath = join(plansDir, params.planPath);
       const planName = basename(planPath);
       const relPath = params.planPath;
+
+      try {
+        await access(planPath);
+      } catch {
+        throw new Error(
+          `Plan file not found: ${toTildePath(planPath)}. Write the file inside ${toTildePath(plansDir)} first, then call review_plan.`,
+        );
+      }
+
       await ensureGitRepo(exec, plansDir);
       await commitFile(exec, plansDir, relPath, `create: ${planName}`);
 
@@ -152,7 +159,15 @@ export function createReviewPlanTool(
       return new PlanReviewCall(theme, plansDir, args.planPath);
     },
 
-    renderResult(result, _options, theme): Component {
+    renderResult(result, _options, theme, context): Component {
+      if (context.isError) {
+        const errorText = result.content
+          .filter((content) => content.type === "text")
+          .map((content) => content.text)
+          .join("");
+
+        return new Text(theme.fg("error", errorText), 0, 0);
+      }
       return new PlanReviewResult(theme, result.details);
     },
   };
@@ -207,7 +222,7 @@ class PlanReviewResult implements Component {
       }
       case "question": {
         this.container.addChild(
-          new Text(theme.fg("accent", `Question: `) + `${details.message ?? ""}`, 0, 0),
+          new Text(`${theme.fg("accent", `Question: `)}${details.message ?? ""}`, 0, 0),
         );
         break;
       }


### PR DESCRIPTION
## Summary

Improves error handling in the `review-plan` tool for two invalid-input scenarios:

### 1. Missing plan file
Before, if the agent called `review_plan` with a path that didn't exist yet, the tool would proceed silently (attempting git operations on a non-existent file). Now it performs an `access()` check upfront and throws a descriptive error:

```
Plan file not found: ~/.pi/plan/repo/name.md.
Write the file inside ~/.pi/plan first, then call review_plan.
```

### 2. Non-interactive mode (no UI)
Before, this returned a `{ result: 'cancel' }` success response with an error message embedded in the text content. Now it throws, so the agent receives a proper tool error and can react accordingly.

### Error rendering
`renderResult` now checks `context.isError` and renders error text using the theme's error colour instead of crashing on a missing `details` object.

## Changes
- `plan-tool.ts`: `access()` guard, `throw` instead of soft cancel, error-aware `renderResult`
- `plan-tool.test.ts`: updated no-UI test, added new 'file not found' test
- Biome `useTemplate` lint fix + formatting