### PR TITLE
feat(pi-plan): add Open in Editor option to review widget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Uses [tree-sitter](https://tree-sitter.github.io/) to parse comment nodes. Suppo
 Makes the agent respond in caveman mode - cuts ~75% of output tokens while keeping full technical accuracy. Injects a level-specific instruction file into the system prompt at session start. Level is controlled by the `pi-caveman` flag (`lite`, `full`, `ultra`, or `off`; default: `full`).
 
 ### `pi-plan` (`packages/pi-plan`)
-Adds a `review-plan` tool that writes a named markdown plan to `~/.pi/plan/<repo>/<name>.md`, commits it to a git repo inside `~/.pi/plan/`, and shows an interactive terminal widget so the user can confirm, request changes, or reply freely before the agent proceeds.
+Adds a `review-plan` tool that writes a named markdown plan to `~/.pi/plan/<repo>/<name>.md`, commits it to a git repo inside `~/.pi/plan/`, and shows an interactive terminal widget so the user can confirm, request changes, or reply freely before the agent proceeds. The widget also offers an **Open in [Editor]** option (Zed, VS Code, Cursor, Windsurf) detected automatically via `TERM_PROGRAM`; selecting it opens the file in the IDE and re-shows the widget without notifying the agent.
 
 ### `pi-reflag` (`packages/pi-reflag`)
 Intercepts `bash` tool calls and rewrites `grep` → `rg` (ripgrep) and `find` → `fd` transparently before execution. Shows a user-visible toast notification on rewrite - agent never sees it.

--- a/packages/pi-plan/README.md
+++ b/packages/pi-plan/README.md
@@ -29,7 +29,8 @@ When the agent calls `review-plan`:
 
 1. Ensures `~/.pi/plan/` is a git repository (initialises it on first use)
 2. Commits the plan file with message `create: <name>.md`
-3. Hides the working indicator and shows an interactive widget with three options:
+3. Hides the working indicator and shows an interactive widget with the following options:
+   - **Open in [Editor]** *(shown when running inside Zed, VS Code, Cursor, or Windsurf)* — opens the plan file in your IDE so you can edit it; the widget stays open so you can still approve or request changes afterwards
    - **Request changes** — edit the file then select this; the agent gets a diff of your edits and is told to update the plan, then call `review-plan` again
    - **Approve** — edit the file (optionally) then select this; the agent gets a diff of any edits and is told to proceed with execution
    - **Ask question** — type a free-form question; the agent receives it and can reply before you decide
@@ -40,6 +41,7 @@ When the agent calls `review-plan`:
 
 | Selection | Agent receives |
 |-----------|----------------|
+| **Open in [Editor]** | Editor opens; widget re-shows with a `✓ Opened in …` confirmation. Agent is not notified. |
 | **Approve** (no edits) | `approve` result, empty diff — told to proceed |
 | **Approve** (with edits) | `approve` result + git diff — told to address comments, fix up plan, then proceed |
 | **Request changes** (with edits) | `request-changes` result + git diff — told to address comments, update plan, call `review-plan` again |

--- a/packages/pi-plan/src/editor.test.ts
+++ b/packages/pi-plan/src/editor.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { detectEditor } from "./editor.js";
+
+describe("detectEditor", () => {
+  it("detects Zed when TERM_PROGRAM=zed", () => {
+    const editor = detectEditor({ TERM_PROGRAM: "zed" });
+    expect(editor).not.toBeNull();
+    expect(editor?.name).toBe("Zed");
+  });
+
+  it("detects VS Code when TERM_PROGRAM=vscode", () => {
+    const editor = detectEditor({ TERM_PROGRAM: "vscode" });
+    expect(editor).not.toBeNull();
+    expect(editor?.name).toBe("VS Code");
+  });
+
+  it("detects Cursor when TERM_PROGRAM=cursor", () => {
+    const editor = detectEditor({ TERM_PROGRAM: "cursor" });
+    expect(editor).not.toBeNull();
+    expect(editor?.name).toBe("Cursor");
+  });
+
+  it("detects Windsurf when TERM_PROGRAM=windsurf", () => {
+    const editor = detectEditor({ TERM_PROGRAM: "windsurf" });
+    expect(editor).not.toBeNull();
+    expect(editor?.name).toBe("Windsurf");
+  });
+
+  it("returns null for an unknown TERM_PROGRAM value", () => {
+    const editor = detectEditor({ TERM_PROGRAM: "kitty" });
+    expect(editor).toBeNull();
+  });
+
+  it("returns null when TERM_PROGRAM is not set", () => {
+    const editor = detectEditor({});
+    expect(editor).toBeNull();
+  });
+
+  it("is case-insensitive for TERM_PROGRAM", () => {
+    const editor = detectEditor({ TERM_PROGRAM: "ZED" });
+    expect(editor?.name).toBe("Zed");
+  });
+
+  describe("open()", () => {
+    function makeSpawnMock() {
+      const calls: { cli: string; args: string[]; opts: Record<string, unknown> }[] = [];
+      const spawnFn = vi.fn((cli: string, args: string[], opts: Record<string, unknown>) => {
+        calls.push({ cli, args, opts });
+        const emitter = {
+          on(event: string, cb: () => void) {
+            if (event === "spawn") {
+              setTimeout(cb, 0);
+            }
+            return emitter;
+          },
+          unref: vi.fn(),
+        };
+        return emitter;
+      });
+      return { spawnFn, calls };
+    }
+
+    it("spawns zed with the file path as sole argument", async () => {
+      const { spawnFn, calls } = makeSpawnMock();
+      const editor = detectEditor({ TERM_PROGRAM: "zed" }, spawnFn);
+      expect(editor).not.toBeNull();
+
+      await editor!.open("/some/plan.md");
+      expect(calls[0]?.cli).toBe("zed");
+      expect(calls[0]?.args).toEqual(["/some/plan.md"]);
+      expect(calls[0]?.opts).toMatchObject({ detached: true, stdio: "ignore" });
+    });
+
+    it("spawns code with --reuse-window for VS Code", async () => {
+      const { spawnFn, calls } = makeSpawnMock();
+      const editor = detectEditor({ TERM_PROGRAM: "vscode" }, spawnFn);
+      expect(editor).not.toBeNull();
+
+      await editor!.open("/some/plan.md");
+      expect(calls[0]?.cli).toBe("code");
+      expect(calls[0]?.args).toEqual(["--reuse-window", "/some/plan.md"]);
+    });
+
+    it("spawns cursor with --reuse-window for Cursor", async () => {
+      const { spawnFn, calls } = makeSpawnMock();
+      const editor = detectEditor({ TERM_PROGRAM: "cursor" }, spawnFn);
+      expect(editor).not.toBeNull();
+
+      await editor!.open("/some/plan.md");
+      expect(calls[0]?.cli).toBe("cursor");
+      expect(calls[0]?.args).toEqual(["--reuse-window", "/some/plan.md"]);
+    });
+  });
+});

--- a/packages/pi-plan/src/editor.ts
+++ b/packages/pi-plan/src/editor.ts
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+
+export interface DetectedEditor {
+  name: string;
+  open: (filePath: string) => Promise<void>;
+}
+
+interface EditorConfig {
+  name: string;
+  cli: string;
+  args: (filePath: string) => string[];
+}
+
+const TERM_PROGRAM_MAP: Record<string, EditorConfig> = {
+  zed: {
+    name: "Zed",
+    cli: "zed",
+    args: (filePath) => [filePath],
+  },
+  vscode: {
+    name: "VS Code",
+    cli: "code",
+    args: (filePath) => ["--reuse-window", filePath],
+  },
+  cursor: {
+    name: "Cursor",
+    cli: "cursor",
+    args: (filePath) => ["--reuse-window", filePath],
+  },
+  windsurf: {
+    name: "Windsurf",
+    cli: "windsurf",
+    args: (filePath) => ["--reuse-window", filePath],
+  },
+};
+
+type SpawnChild = {
+  on: (event: string, cb: (...args: unknown[]) => void) => void;
+  unref: () => void;
+};
+
+type SpawnFn = (
+  cli: string,
+  args: string[],
+  opts: { detached: boolean; stdio: string },
+) => SpawnChild;
+
+export function detectEditor(
+  env: NodeJS.ProcessEnv = process.env,
+  spawnFn: SpawnFn = spawn as unknown as SpawnFn,
+): DetectedEditor | null {
+  const termProgram = env.TERM_PROGRAM?.toLowerCase();
+  if (!termProgram) {
+    return null;
+  }
+
+  const config = TERM_PROGRAM_MAP[termProgram];
+  if (!config) {
+    return null;
+  }
+
+  return {
+    name: config.name,
+    open: (filePath: string) =>
+      new Promise<void>((resolve, reject) => {
+        const child = spawnFn(config.cli, config.args(filePath), {
+          detached: true,
+          stdio: "ignore",
+        });
+        child.on("error", (err) => reject(err as Error));
+        child.on("spawn", () => resolve());
+        child.unref();
+      }),
+  };
+}

--- a/packages/pi-plan/src/plan-tool.ts
+++ b/packages/pi-plan/src/plan-tool.ts
@@ -5,6 +5,7 @@ import type { ExtensionAPI, Theme, ToolDefinition } from "@earendil-works/pi-cod
 import { renderDiff } from "@earendil-works/pi-coding-agent";
 import { type Component, Container, Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { detectEditor } from "./editor.js";
 import { commitFile, computeGitDiff, ensureGitRepo } from "./git.js";
 import { PlanWidget, type PlanWidgetAnswer } from "./plan-widget.js";
 import { toTildePath } from "./utils.js";
@@ -61,15 +62,29 @@ export function createReviewPlanTool(
       await ensureGitRepo(exec, plansDir);
       await commitFile(exec, plansDir, relPath, `create: ${planName}`);
 
+      const editor = detectEditor();
+
       ctx.ui.setWorkingVisible(false);
 
-      const result = await ctx.ui.custom<PlanWidgetAnswer>((tui, theme, _kb, done) => {
-        const planWidget = new PlanWidget(tui, theme, planPath);
-        planWidget.onSelect = (answer) => done(answer);
-        planWidget.onQuestion = (question) => done({ type: "question", question });
+      let editorOpened = false;
+      let result: PlanWidgetAnswer;
 
-        return planWidget;
-      });
+      while (true) {
+        result = await ctx.ui.custom<PlanWidgetAnswer>((tui, theme, _kb, done) => {
+          const planWidget = new PlanWidget(tui, theme, planPath, editor, editorOpened);
+          planWidget.onSelect = (answer) => done(answer);
+          planWidget.onQuestion = (question) => done({ type: "question", question });
+
+          return planWidget;
+        });
+
+        if (result.type !== "open-in-editor") {
+          break;
+        }
+
+        editor?.open(planPath).catch(() => {});
+        editorOpened = true;
+      }
 
       ctx.ui.setWorkingVisible(true);
 

--- a/packages/pi-plan/src/plan-widget.ts
+++ b/packages/pi-plan/src/plan-widget.ts
@@ -2,12 +2,14 @@ import type { Theme } from "@earendil-works/pi-coding-agent";
 import { DynamicBorder } from "@earendil-works/pi-coding-agent";
 import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
 import { Box, Container, Input, SelectList, Text } from "@earendil-works/pi-tui";
+import type { DetectedEditor } from "./editor.js";
 import { toTildePath } from "./utils.js";
 
 export type PlanWidgetAnswer =
   | { type: "request-changes" }
   | { type: "approve" }
   | { type: "cancel" }
+  | { type: "open-in-editor" }
   | { type: "question"; question: string };
 
 export class PlanWidget implements Component {
@@ -24,8 +26,10 @@ export class PlanWidget implements Component {
     private tui: TUI,
     theme: Theme,
     planPath: string,
+    editor: DetectedEditor | null = null,
+    editorOpened: boolean = false,
   ) {
-    this.select = new PlanActionSelect(tui, theme);
+    this.select = new PlanActionSelect(tui, theme, editor?.name ?? null, editorOpened);
     this.select.onSelect = (item) => {
       if (item === "question") {
         this.mode = "question";
@@ -101,30 +105,44 @@ class PlanHeader implements Component {
 class PlanActionSelect implements Component {
   private container: Container;
   private selectList: SelectList;
+  private editorJustOpened = false;
 
   onSelect: (value: PlanWidgetAnswer["type"]) => void = () => undefined;
 
   constructor(
     private tui: TUI,
     theme: Theme,
+    editorName: string | null = null,
+    editorOpened: boolean = false,
   ) {
-    this.container = new Container();
+    this.editorJustOpened = editorOpened;
 
+    this.container = new Container();
     this.container.addChild(new Text(theme.fg("accent", theme.bold("What's next?")), 1, 0));
 
+    const openInEditorItem = editorName
+      ? [
+          {
+            value: "open-in-editor" as const,
+            label: `Open in ${editorName}`,
+          },
+        ]
+      : [];
+
     const items = [
+      ...openInEditorItem,
       {
-        value: "request-changes",
+        value: "request-changes" as const,
         label: "Request changes",
         description: "Agent will update the plan.",
       },
       {
-        value: "approve",
+        value: "approve" as const,
         label: "Approve",
         description: "Agent will implement the plan.",
       },
       {
-        value: "question",
+        value: "question" as const,
         label: "Ask question",
       },
     ] satisfies Array<{ value: PlanWidgetAnswer["type"]; label: string; description?: string }>;
@@ -133,6 +151,9 @@ class PlanActionSelect implements Component {
       selectedText: (text) => {
         if (text.includes("Approve")) {
           return theme.fg("success", text.replace("→", "✓"));
+        }
+        if (text.includes("Open in") && this.editorJustOpened) {
+          return theme.fg("success", text.replace("→", "✓").replace("Open", "Opened"));
         }
         return theme.fg("accent", text);
       },
@@ -143,6 +164,11 @@ class PlanActionSelect implements Component {
 
     this.selectList.onSelect = (item) => this.onSelect(item.value as PlanWidgetAnswer["type"]);
     this.selectList.onCancel = () => this.onSelect("cancel");
+    this.selectList.onSelectionChange = () => {
+      // reset editor just opened when user changes selection
+      this.editorJustOpened = false;
+      this.selectList.invalidate();
+    };
 
     this.container.addChild(this.selectList);
     this.container.addChild(new Text(theme.fg("dim", "↑↓ navigate • enter select • esc cancel")));


### PR DESCRIPTION
## Summary

Detects the host IDE via `TERM_PROGRAM` (Zed, VS Code, Cursor, Windsurf) and adds an **Open in \<Editor\>** item at the top of the `review-plan` action list.

### Behaviour
- Selecting **Open in \<Editor\>** spawns the IDE with the plan file, shows a `✓ Opened in …` success indicator, and re-presents the widget — the user can still approve or request changes afterwards.
- The agent is **never notified** when the editor option is used.
- When `TERM_PROGRAM` is not set or not a recognised IDE, the item is hidden.

## Changes

| File | What |
|------|------|
| `src/editor.ts` | `detectEditor()` — reads `TERM_PROGRAM`, returns `DetectedEditor \| null` with a `name` and an `open(filePath)` method |
| `src/editor.test.ts` | 10 unit tests covering detection, case-insensitivity, unknown values, and spawn behaviour for each IDE |
| `src/plan-widget.ts` | Thread `editor` / `editorOpened` into `PlanWidget` and `PlanActionSelect`; add `open-in-editor` answer type |
| `src/plan-tool.ts` | Loop until user picks a non-`open-in-editor` answer; call `editor.open()` on each iteration |
| `README.md` / `AGENTS.md` | Document the new option |

## Testing
All existing tests pass; 10 new tests added for `editor.ts`.