### PR TITLE
chore: add Superset workspace setup config

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,6 @@
+{
+  "setup": [
+    "pnpm install",
+    "mkdir -p .git/hooks && printf '#!/usr/bin/env bash\\nset -euo pipefail\\npnpm lefthook run pre-commit\\n' > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit"
+  ]
+}


### PR DESCRIPTION
Adds `.superset/config.json` with setup commands for new workspaces:

- `pnpm install` — installs all workspace deps
- git hook wiring for pre-commit (lefthook, as documented in AGENTS.md)

No teardown or run commands needed — no services, no dev server.