### PR TITLE
feat(pi-reflag): add pi-reflag-no-ignore flag for fd --no-ignore control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,10 +61,14 @@ The `subagent:templates` command opens an interactive terminal menu listing all 
 Intercepts `bash` tool calls and rewrites `grep` → `rg` (ripgrep) and `find` → `fd` transparently before execution. Shows a user-visible toast notification on rewrite - agent never sees it.
 
 - **grep → rg**: drops `-r`/`-R`/`-E`, maps long flags, converts `--include`/`--exclude` to `-g` globs, converts BRE patterns to ERE.
-- **find → fd**: translates `-name`/`-iname` to `-g` globs (OR patterns become brace expansion), `-type`, `-maxdepth`/`-mindepth`, `-exec`/`-execdir`, `-mtime`/`-size`/`-user`/`-group` and more. Always adds `-H` (fd excludes hidden files by default, find doesn't).
+- **find → fd**: translates `-name`/`-iname` to `-g` globs (OR patterns become brace expansion), `-type`, `-maxdepth`/`-mindepth`, `-exec`/`-execdir`, `-mtime`/`-size`/`-user`/`-group` and more. Always adds `-H` (fd excludes hidden files by default, find doesn't). Adds `--no-ignore` when `pi-reflag-no-ignore` flag is set.
 - **xargs**: `xargs grep`/`xargs find` rewrites are also supported.
 
-Skips commands with subshells or variable assignments. Enable verbose logging with `pi-reflag-verbose` flag to see rewrites in the UI.
+Skips commands with subshells or variable assignments.
+
+Flags:
+- `pi-reflag-verbose` (boolean, default: false) — show a toast with original and rewritten command in the UI
+- `pi-reflag-no-ignore` (boolean, default: false) — pass `--no-ignore` to `fd` when translating `find` commands (useful when searching inside directories with their own `.gitignore`, e.g. `.venv`)
 
 ## Tech stack
 

--- a/packages/pi-reflag/src/find.test.ts
+++ b/packages/pi-reflag/src/find.test.ts
@@ -526,3 +526,18 @@ describe("unknown flags", () => {
     expect(t([".", "-delete"])).toBeUndefined();
   });
 });
+
+describe("noIgnore param", () => {
+  it("noIgnore=true adds --no-ignore after -H", () => {
+    expect(translateFindArgs([".", "-name", "*.py"], true)).toEqual([
+      "-H",
+      "--no-ignore",
+      "-g",
+      "*.py",
+    ]);
+  });
+
+  it("noIgnore=false (default) omits --no-ignore", () => {
+    expect(translateFindArgs([".", "-name", "*.py"])).toEqual(["-H", "-g", "*.py"]);
+  });
+});

--- a/packages/pi-reflag/src/find.ts
+++ b/packages/pi-reflag/src/find.ts
@@ -8,14 +8,16 @@
 import type { CommandRewrite } from "./types.js";
 import { xargs } from "./xargs.js";
 
-export const find: CommandRewrite = xargs((command) => {
-  if (command.name === "find") {
-    const args = translateFindArgs(command.args);
-    if (args) {
-      return { name: "fd", args };
+export function createFind(noIgnore: boolean): CommandRewrite {
+  return xargs((command) => {
+    if (command.name === "find") {
+      const args = translateFindArgs(command.args, noIgnore);
+      if (args) {
+        return { name: "fd", args };
+      }
     }
-  }
-});
+  });
+}
 
 function translateDuration(val: string, unit: "d" | "min"): string[] | undefined {
   if (val.startsWith("-")) {
@@ -350,8 +352,11 @@ function translateExpressions(args: string[], cursor: number): ExpressionResult 
   return { translated, globPatterns, regexPattern, execArgs, caseInsensitive, hasIname, hasName };
 }
 
-export function translateFindArgs(args: string[]): string[] | undefined {
+export function translateFindArgs(args: string[], noIgnore = false): string[] | undefined {
   const result: string[] = ["-H"];
+  if (noIgnore) {
+    result.push("--no-ignore");
+  }
 
   const leading = collectLeadingOptions(args);
   result.push(...leading.options);

--- a/packages/pi-reflag/src/index.ts
+++ b/packages/pi-reflag/src/index.ts
@@ -7,13 +7,18 @@ export default function piReflag(pi: ExtensionAPI): void {
     description: "Render how command was reflagged in the ui.",
   });
 
+  pi.registerFlag("pi-reflag-no-ignore", {
+    type: "boolean",
+    description: "Pass --no-ignore to fd when translating find commands.",
+  });
+
   pi.on("tool_call", async (event, ctx) => {
     if (!isToolCallEventType("bash", event)) {
       return undefined;
     }
 
     const original = event.input.command;
-    const rewritten = await rewriteBash(original);
+    const rewritten = await rewriteBash(original, !!pi.getFlag("pi-reflag-no-ignore"));
 
     if (rewritten === original) {
       return undefined;

--- a/packages/pi-reflag/src/shell.ts
+++ b/packages/pi-reflag/src/shell.ts
@@ -1,10 +1,8 @@
 import type { Parser, Node as SyntaxNode } from "web-tree-sitter";
-import { find } from "./find.js";
+import { createFind } from "./find.js";
 import { grep } from "./grep.js";
 import { loadBashParser } from "./tree-sitter.js";
 import type { Command } from "./types.js";
-
-const COMMAND_REWRITES = [grep, find];
 
 const REDIRECT_NODE_TYPES = new Set(["file_redirect", "heredoc_redirect", "herestring_redirect"]);
 
@@ -13,7 +11,7 @@ interface BashCommand extends Command {
   endIndex: number;
 }
 
-export async function rewriteBash(bash: string): Promise<string> {
+export async function rewriteBash(bash: string, noIgnore = false): Promise<string> {
   let parser: Parser | undefined;
   try {
     parser = await loadBashParser();
@@ -28,8 +26,10 @@ export async function rewriteBash(bash: string): Promise<string> {
 
   let newBash = bash;
 
+  const rewrites = [grep, createFind(noIgnore)];
+
   for (const command of extractCommands(tree.rootNode)) {
-    for (const rewrite of COMMAND_REWRITES) {
+    for (const rewrite of rewrites) {
       const newCommand = rewrite(command);
 
       if (newCommand) {


### PR DESCRIPTION
## Summary

Adds a `pi-reflag-no-ignore` boolean flag to control whether `--no-ignore` is passed to `fd` when translating `find` commands. Disabled by default, preserving fd's gitignore-aware filtering.

## Motivation

`fd` respects `.gitignore` files by default, which differs from `find`. When searching inside directories that have their own `.gitignore` (e.g. Python `.venv` which ships with `*`), fd finds nothing while find works fine.

Setting `pi-reflag-no-ignore: true` makes fd behave like find in these cases.

## Changes

- `find.ts`: export `createFind(noIgnore)` factory; `translateFindArgs` accepts `noIgnore` param
- `shell.ts`: `rewriteBash(bash, noIgnore)` threads flag through to find rewrite
- `index.ts`: register `pi-reflag-no-ignore` flag, pass it to `rewriteBash` on each tool call
- `AGENTS.md`: document both flags with descriptions and use cases

## Notes

An earlier approach attempted automatic detection (walking gitignore files, checking if paths are ignored). It was removed as overly complex and not fully correct — explicit user control is simpler and more reliable.