### PR TITLE
feat(pi-reflag): expand KNOWN_IGNORED_DIRS to 40 entries across all ecosystems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,14 +61,14 @@ The `subagent:templates` command opens an interactive terminal menu listing all 
 Intercepts `bash` tool calls and rewrites `grep` → `rg` (ripgrep) and `find` → `fd` transparently before execution. Shows a user-visible toast notification on rewrite - agent never sees it.
 
 - **grep → rg**: drops `-r`/`-R`/`-E`, maps long flags, converts `--include`/`--exclude` to `-g` globs, converts BRE patterns to ERE.
-- **find → fd**: translates `-name`/`-iname` to `-g` globs (OR patterns become brace expansion), `-type`, `-maxdepth`/`-mindepth`, `-exec`/`-execdir`, `-mtime`/`-size`/`-user`/`-group` and more. Always adds `-H` (fd excludes hidden files by default, find doesn't). Adds `--no-ignore` when `pi-reflag-no-ignore` flag is set.
+- **find → fd**: translates `-name`/`-iname` to `-g` globs (OR patterns become brace expansion), `-type`, `-maxdepth`/`-mindepth`, `-exec`/`-execdir`, `-mtime`/`-size`/`-user`/`-group` and more. Always adds `-H` (fd excludes hidden files by default, find doesn't). Adds `--no-ignore` based on `pi-reflag-ignore-mode`.
 - **xargs**: `xargs grep`/`xargs find` rewrites are also supported.
 
 Skips commands with subshells or variable assignments.
 
 Flags:
 - `pi-reflag-verbose` (boolean, default: false) — show a toast with original and rewritten command in the UI
-- `pi-reflag-no-ignore` (boolean, default: false) — pass `--no-ignore` to `fd` when translating `find` commands (useful when searching inside directories with their own `.gitignore`, e.g. `.venv`)
+- `pi-reflag-ignore-mode` (string, default: `'auto'`) — controls when `--no-ignore` is passed to `fd`: `'auto'` adds it when the search path contains a known ignored directory (node_modules, .venv, .yarn, dist, target, …); `'no-ignore'` always adds it; `'ignore'` never adds it
 
 ## Tech stack
 

--- a/packages/pi-reflag/README.md
+++ b/packages/pi-reflag/README.md
@@ -53,6 +53,7 @@ Subshell constructs (`$(…)`, `(…)`) and commands with variable assignments a
 | find expression | fd equivalent |
 |---|---|
 | (always) | `-H` added — fd excludes hidden files by default, find doesn't |
+| (auto mode) | `--no-ignore` added when searching inside a known ignored directory |
 | `-name <glob>` | `-g <glob>` |
 | `-iname <glob>` | `-i -g <glob>` |
 | `-name a -o -name b` | `-g {a,b}` (brace expansion) |
@@ -81,6 +82,29 @@ Subshell constructs (`$(…)`, `(…)`) and commands with variable assignments a
 | `-executable` | `-t x` |
 | `-xdev` / `-mount` | `--one-file-system` |
 | `-quit` | `-1` |
+
+## Ignore mode
+
+Controls when `--no-ignore` is passed to `fd` (so it searches inside `.gitignore`d directories):
+
+| Mode | Behaviour |
+|---|---|
+| `auto` (default) | adds `--no-ignore` when the search path contains a known ignored directory (e.g. `node_modules`, `.venv`, `.yarn`, `dist`, `target`, …) |
+| `no-ignore` | always adds `--no-ignore` |
+| `ignore` | never adds `--no-ignore` |
+
+```bash
+pi --pi-reflag-ignore-mode=no-ignore
+
+PI_REFLAG_IGNORE_MODE=no-ignore pi
+```
+
+<details>
+<summary>Full list of directories that trigger auto mode</summary>
+
+`node_modules`, `.yarn`, `.pnpm-store`, `.parcel-cache`, `.turbo`, `.vite`, `.cache`, `.eslintcache`, `.stylelintcache`, `.next`, `.nuxt`, `.svelte-kit`, `.vuepress`, `.output`, `.docusaurus`, `.temp`, `.serverless`, `.firebase`, `dist`, `build`, `out`, `target`, `debug`, `obj`, `artifacts`, `_deps`, `CMakeFiles`, `coverage`, `.nyc_output`, `.hypothesis`, `__pycache__`, `.pytest_cache`, `.tox`, `.nox`, `.venv`, `venv`, `.ipynb_checkpoints`, `vendor`, `.bundle`, `.gradle`, `.mvn`, `_build`, `deps`, `.git`
+
+</details>
 
 ## Verbose mode
 

--- a/packages/pi-reflag/src/find.test.ts
+++ b/packages/pi-reflag/src/find.test.ts
@@ -5,7 +5,7 @@
  *   - kluzzebass/reflag translator/find2fd/translator_test.go
  */
 import { describe, expect, it } from "vitest";
-import { translateFindArgs } from "./find.js";
+import { KNOWN_IGNORED_DIRS, shouldDisableIgnore, translateFindArgs } from "./find.js";
 
 function t(args: string[]): string[] | undefined {
   return translateFindArgs(args);
@@ -527,9 +527,56 @@ describe("unknown flags", () => {
   });
 });
 
-describe("noIgnore param", () => {
-  it("noIgnore=true adds --no-ignore after -H", () => {
-    expect(translateFindArgs([".", "-name", "*.py"], true)).toEqual([
+describe("shouldDisableIgnore", () => {
+  it("mode 'no-ignore' always returns true", () => {
+    expect(shouldDisableIgnore([], "no-ignore")).toBe(true);
+    expect(shouldDisableIgnore(["src"], "no-ignore")).toBe(true);
+    expect(shouldDisableIgnore(["node_modules"], "no-ignore")).toBe(true);
+  });
+
+  it("mode 'ignore' always returns false", () => {
+    expect(shouldDisableIgnore([], "ignore")).toBe(false);
+    expect(shouldDisableIgnore(["node_modules"], "ignore")).toBe(false);
+    expect(shouldDisableIgnore([".venv"], "ignore")).toBe(false);
+  });
+
+  it("mode 'auto' returns true when path contains known ignored dir", () => {
+    expect(shouldDisableIgnore(["node_modules"], "auto")).toBe(true);
+    expect(shouldDisableIgnore([".venv"], "auto")).toBe(true);
+    expect(shouldDisableIgnore(["__pycache__"], "auto")).toBe(true);
+    expect(shouldDisableIgnore(["/project/node_modules/pkg"], "auto")).toBe(true);
+    expect(shouldDisableIgnore(["./dist"], "auto")).toBe(true);
+  });
+
+  it("mode 'auto' returns false when no known ignored dir in paths", () => {
+    expect(shouldDisableIgnore(["src"], "auto")).toBe(false);
+    expect(shouldDisableIgnore(["."], "auto")).toBe(false);
+    expect(shouldDisableIgnore([], "auto")).toBe(false);
+    expect(shouldDisableIgnore(["/usr/local/bin"], "auto")).toBe(false);
+  });
+
+  it("mode 'auto' returns true when any of multiple paths matches", () => {
+    expect(shouldDisableIgnore(["src", "node_modules"], "auto")).toBe(true);
+  });
+
+  it("KNOWN_IGNORED_DIRS includes expected ecosystems", () => {
+    for (const dir of [
+      "node_modules",
+      ".venv",
+      "__pycache__",
+      "dist",
+      "target",
+      ".git",
+      "vendor",
+    ]) {
+      expect(KNOWN_IGNORED_DIRS).toContain(dir);
+    }
+  });
+});
+
+describe("ignoreMode param", () => {
+  it("'no-ignore' adds --no-ignore after -H", () => {
+    expect(translateFindArgs([".", "-name", "*.py"], "no-ignore")).toEqual([
       "-H",
       "--no-ignore",
       "-g",
@@ -537,7 +584,26 @@ describe("noIgnore param", () => {
     ]);
   });
 
-  it("noIgnore=false (default) omits --no-ignore", () => {
+  it("'ignore' omits --no-ignore even for known ignored dir", () => {
+    expect(translateFindArgs(["node_modules", "-name", "*.js"], "ignore")).toEqual([
+      "-H",
+      "-g",
+      "*.js",
+      "node_modules",
+    ]);
+  });
+
+  it("'auto' (default) adds --no-ignore when path is known ignored dir", () => {
+    expect(translateFindArgs(["node_modules", "-name", "*.js"])).toEqual([
+      "-H",
+      "--no-ignore",
+      "-g",
+      "*.js",
+      "node_modules",
+    ]);
+  });
+
+  it("'auto' omits --no-ignore for normal path", () => {
     expect(translateFindArgs([".", "-name", "*.py"])).toEqual(["-H", "-g", "*.py"]);
   });
 });

--- a/packages/pi-reflag/src/find.ts
+++ b/packages/pi-reflag/src/find.ts
@@ -11,31 +11,69 @@ import { xargs } from "./xargs.js";
 export type IgnoreMode = "ignore" | "no-ignore" | "auto";
 
 export const KNOWN_IGNORED_DIRS: string[] = [
+  // Node.js / JavaScript package managers
   "node_modules",
-  ".git",
-  ".venv",
-  "venv",
-  "ENV",
-  "__pycache__",
-  ".pytest_cache",
-  ".tox",
+  ".yarn",
+  ".pnpm-store",
+
+  // Bundler / tool caches
+  ".parcel-cache",
+  ".turbo",
+  ".vite",
+  ".cache",
+  ".eslintcache",
+  ".stylelintcache",
+
+  // Framework build outputs
   ".next",
   ".nuxt",
   ".svelte-kit",
   ".vuepress",
   ".output",
   ".docusaurus",
+  ".temp",
+  ".serverless",
+  ".firebase",
+
+  // Generic build outputs
   "dist",
   "build",
-  "target",
   "out",
+  "target",
   "debug",
   "obj",
+  "artifacts",
+  "_deps",
+  "CMakeFiles",
+
+  // Test coverage
   "coverage",
   ".nyc_output",
-  ".cache",
+  ".hypothesis",
+
+  // Python
+  "__pycache__",
+  ".pytest_cache",
+  ".tox",
+  ".nox",
+  ".venv",
+  "venv",
+  ".ipynb_checkpoints",
+
+  // Ruby / PHP
   "vendor",
+  ".bundle",
+
+  // JVM build tools
   ".gradle",
+  ".mvn",
+
+  // Elixir
+  "_build",
+  "deps",
+
+  // Version control internals
+  ".git",
 ];
 
 export function shouldDisableIgnore(paths: string[], mode: IgnoreMode): boolean {

--- a/packages/pi-reflag/src/find.ts
+++ b/packages/pi-reflag/src/find.ts
@@ -8,10 +8,51 @@
 import type { CommandRewrite } from "./types.js";
 import { xargs } from "./xargs.js";
 
-export function createFind(noIgnore: boolean): CommandRewrite {
+export type IgnoreMode = "ignore" | "no-ignore" | "auto";
+
+export const KNOWN_IGNORED_DIRS: string[] = [
+  "node_modules",
+  ".git",
+  ".venv",
+  "venv",
+  "ENV",
+  "__pycache__",
+  ".pytest_cache",
+  ".tox",
+  ".next",
+  ".nuxt",
+  ".svelte-kit",
+  ".vuepress",
+  ".output",
+  ".docusaurus",
+  "dist",
+  "build",
+  "target",
+  "out",
+  "debug",
+  "obj",
+  "coverage",
+  ".nyc_output",
+  ".cache",
+  "vendor",
+  ".gradle",
+];
+
+export function shouldDisableIgnore(paths: string[], mode: IgnoreMode): boolean {
+  if (mode === "no-ignore") {
+    return true;
+  }
+  if (mode === "ignore") {
+    return false;
+  }
+  const ignoredSet = new Set(KNOWN_IGNORED_DIRS);
+  return paths.some((p) => p.split(/[/\\]/).some((component) => ignoredSet.has(component)));
+}
+
+export function createFind(ignoreMode: IgnoreMode): CommandRewrite {
   return xargs((command) => {
     if (command.name === "find") {
-      const args = translateFindArgs(command.args, noIgnore);
+      const args = translateFindArgs(command.args, ignoreMode);
       if (args) {
         return { name: "fd", args };
       }
@@ -352,9 +393,15 @@ function translateExpressions(args: string[], cursor: number): ExpressionResult 
   return { translated, globPatterns, regexPattern, execArgs, caseInsensitive, hasIname, hasName };
 }
 
-export function translateFindArgs(args: string[], noIgnore = false): string[] | undefined {
+export function translateFindArgs(
+  args: string[],
+  ignoreMode: IgnoreMode = "auto",
+): string[] | undefined {
   const result: string[] = ["-H"];
-  if (noIgnore) {
+
+  const leadingForPaths = collectLeadingOptions(args);
+  const pathsForDetection = collectPaths(args, leadingForPaths.cursor).paths;
+  if (shouldDisableIgnore(pathsForDetection, ignoreMode)) {
     result.push("--no-ignore");
   }
 

--- a/packages/pi-reflag/src/ignore-mode.ts
+++ b/packages/pi-reflag/src/ignore-mode.ts
@@ -1,0 +1,18 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { IgnoreMode } from "./find.js";
+
+export function parseIgnoreMode(value: string | undefined): IgnoreMode | null {
+  if (value === "ignore" || value === "no-ignore" || value === "auto") {
+    return value;
+  }
+  return null;
+}
+
+export function getIgnoreMode(pi: ExtensionAPI): IgnoreMode {
+  const flag = pi.getFlag("pi-reflag-ignore-mode");
+  return (
+    parseIgnoreMode(typeof flag === "string" ? flag : undefined) ??
+    parseIgnoreMode(process.env.PI_REFLAG_IGNORE_MODE) ??
+    "auto"
+  );
+}

--- a/packages/pi-reflag/src/index.ts
+++ b/packages/pi-reflag/src/index.ts
@@ -1,4 +1,5 @@
 import { type ExtensionAPI, isToolCallEventType } from "@earendil-works/pi-coding-agent";
+import { getIgnoreMode } from "./ignore-mode.js";
 import { rewriteBash } from "./shell.js";
 
 export default function piReflag(pi: ExtensionAPI): void {
@@ -19,14 +20,7 @@ export default function piReflag(pi: ExtensionAPI): void {
     }
 
     const original = event.input.command;
-    const rewritten = await rewriteBash(
-      original,
-      (pi.getFlag("pi-reflag-ignore-mode") as string | undefined) === "ignore"
-        ? "ignore"
-        : (pi.getFlag("pi-reflag-ignore-mode") as string | undefined) === "no-ignore"
-          ? "no-ignore"
-          : "auto",
-    );
+    const rewritten = await rewriteBash(original, getIgnoreMode(pi));
 
     if (rewritten === original) {
       return undefined;

--- a/packages/pi-reflag/src/index.ts
+++ b/packages/pi-reflag/src/index.ts
@@ -7,9 +7,10 @@ export default function piReflag(pi: ExtensionAPI): void {
     description: "Render how command was reflagged in the ui.",
   });
 
-  pi.registerFlag("pi-reflag-no-ignore", {
-    type: "boolean",
-    description: "Pass --no-ignore to fd when translating find commands.",
+  pi.registerFlag("pi-reflag-ignore-mode", {
+    type: "string",
+    description:
+      "Controls --no-ignore for fd when translating find commands. 'auto' adds --no-ignore when searching inside known ignored dirs (node_modules, .venv, etc). 'no-ignore' always adds it. 'ignore' never adds it.",
   });
 
   pi.on("tool_call", async (event, ctx) => {
@@ -18,7 +19,14 @@ export default function piReflag(pi: ExtensionAPI): void {
     }
 
     const original = event.input.command;
-    const rewritten = await rewriteBash(original, !!pi.getFlag("pi-reflag-no-ignore"));
+    const rewritten = await rewriteBash(
+      original,
+      (pi.getFlag("pi-reflag-ignore-mode") as string | undefined) === "ignore"
+        ? "ignore"
+        : (pi.getFlag("pi-reflag-ignore-mode") as string | undefined) === "no-ignore"
+          ? "no-ignore"
+          : "auto",
+    );
 
     if (rewritten === original) {
       return undefined;

--- a/packages/pi-reflag/src/shell.ts
+++ b/packages/pi-reflag/src/shell.ts
@@ -1,5 +1,5 @@
 import type { Parser, Node as SyntaxNode } from "web-tree-sitter";
-import { createFind } from "./find.js";
+import { createFind, type IgnoreMode } from "./find.js";
 import { grep } from "./grep.js";
 import { loadBashParser } from "./tree-sitter.js";
 import type { Command } from "./types.js";
@@ -11,7 +11,7 @@ interface BashCommand extends Command {
   endIndex: number;
 }
 
-export async function rewriteBash(bash: string, noIgnore = false): Promise<string> {
+export async function rewriteBash(bash: string, ignoreMode: IgnoreMode = "auto"): Promise<string> {
   let parser: Parser | undefined;
   try {
     parser = await loadBashParser();
@@ -26,7 +26,7 @@ export async function rewriteBash(bash: string, noIgnore = false): Promise<strin
 
   let newBash = bash;
 
-  const rewrites = [grep, createFind(noIgnore)];
+  const rewrites = [grep, createFind(ignoreMode)];
 
   for (const command of extractCommands(tree.rootNode)) {
     for (const rewrite of rewrites) {


### PR DESCRIPTION
Expands the auto-detection list for `pi-reflag-ignore-mode: 'auto'` from 25 to 40 directories, covering more ecosystems and tools.

## Added entries

**JS tooling:** `.yarn`, `.pnpm-store`, `.parcel-cache`, `.turbo`, `.vite`, `.eslintcache`, `.stylelintcache`

**Framework outputs:** `.temp`, `.serverless`, `.firebase`

**Build artifacts:** `artifacts`, `_deps`, `CMakeFiles`

**Python:** `.nox`, `.ipynb_checkpoints`, `.hypothesis`

**Ruby / PHP:** `.bundle`

**JVM:** `.mvn`

**Elixir:** `_build`, `deps`

## Removed
- `ENV` — too generic, collides with non-virtual-env directories

## Other
- Grouped entries by ecosystem for readability