### PR TITLE
feat(pi-title): add pi-title extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ included_tools: edit, write, bash
 The `subagent:templates` command opens an interactive terminal menu listing all loaded templates with their source and model.
 
 ### `pi-title` (`packages/pi-title`)
-Generates short session title from user messages. Hooks `before_agent_start`, accumulates recent user prompts, calls `complete()` with active model in background (non-blocking), sets name via `pi.setSessionName()`. Title locks after first prompt ≥ 40 chars. Max title length: 40 chars.
+Generates short session title from user messages. Hooks `before_agent_start`, accumulates recent user prompts, calls `complete()` with active model in background (non-blocking), sets name via `pi.setSessionName()`. Title locks once total accumulated user prompt content (current + previous messages) reaches 40 chars. Max title length: 40 chars.
 
 Exposes `/title` command to manually regenerate title from recent session context.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,13 @@ included_tools: edit, write, bash
 
 The `subagent:templates` command opens an interactive terminal menu listing all loaded templates with their source and model.
 
+### `pi-title` (`packages/pi-title`)
+Generates short session title from user messages. Hooks `before_agent_start`, accumulates recent user prompts, calls `complete()` with active model in background (non-blocking), sets name via `pi.setSessionName()`. Title locks after first prompt ≥ 40 chars. Max title length: 40 chars.
+
+Exposes `/title` command to manually regenerate title from recent session context.
+
+No flags — constants are hardcoded (`MAX_TITLE_LENGTH = 40`, `MIN_PROMPT_LENGTH = 60`).
+
 ### `pi-reflag` (`packages/pi-reflag`)
 Intercepts `bash` tool calls and rewrites `grep` → `rg` (ripgrep) and `find` → `fd` transparently before execution. Shows a user-visible toast notification on rewrite - agent never sees it.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A monorepo of [pi coding agent](https://github.com/earendil-works/pi) extensions
 | [`@piotr-oles/pi-reflag`](packages/pi-reflag) | Transparently rewrites `grep` → `rg` (ripgrep) and `find` → `fd` before they execute — faster searches, zero agent behavior change |
 | [`@piotr-oles/pi-cwd`](packages/pi-cwd) | Reminds agent to use relative paths — detects absolute cwd paths in `read`/`write`/`edit`/`bash` calls and appends a tip to the tool result |
 | [`@piotr-oles/pi-subagents`](packages/pi-subagents) | Lets the agent spawn specialized subagents — each running in its own isolated session with its own model, tools, and instructions |
+| [`@piotr-oles/pi-title`](packages/pi-title) | Generates a short session title from the first user message using the active model |
 
 ## Development
 

--- a/packages/pi-title/README.md
+++ b/packages/pi-title/README.md
@@ -1,0 +1,52 @@
+# pi-title
+
+Pi Agent extension that generates short session title from user messages.
+
+On each agent turn, extension calls active model in background and sets concise, specific title (up to 40 characters) — no user action needed.
+
+## Usage
+
+Install via pi config:
+
+```bash
+pi install npm:@piotr-oles/pi-title
+```
+
+## Behavior
+
+- Hooks `before_agent_start` — fires every turn until title is locked in.
+- Title locks after first message that is ≥ 40 chars (prompt long enough to be specific).
+- Generates title in background — agent starts immediately, no added latency.
+- Uses same model and API key as active session.
+- Sets session name via `pi.setSessionName()`.
+- If model unavailable, throws and shows notification.
+
+## `/title` command
+
+Run `/title` anytime to regenerate title from recent prompts:
+
+```
+/title
+```
+
+Aborts any in-progress auto-generation, calls model with recent session context, and notifies when done.
+
+## Title generation
+
+Prompt instructs model to produce single sentence-case title (max 40 chars, no quotes), specific to task, file, or topic. When session already has title, model refines it if newer prompts add context.
+
+Examples:
+
+| First message | Generated title |
+|---|---|
+| "Add dark mode toggle to the settings page" | Add dark mode to settings page |
+| "Why is the auth middleware throwing 401?" | Debug 401 in auth middleware |
+| "Refactor UserService to use repository pattern" | Refactor UserService repository |
+
+## Development
+
+Test changes manually by passing source entry point to pi with `-e` flag:
+
+```bash
+pi -ne -e packages/pi-title/src/index.ts
+```

--- a/packages/pi-title/README.md
+++ b/packages/pi-title/README.md
@@ -15,7 +15,7 @@ pi install npm:@piotr-oles/pi-title
 ## Behavior
 
 - Hooks `before_agent_start` — fires every turn until title is locked in.
-- Title locks after first message that is ≥ 40 chars (prompt long enough to be specific).
+- Title locks once total accumulated user prompt content (current + previous messages) reaches 40 chars.
 - Generates title in background — agent starts immediately, no added latency.
 - Uses same model and API key as active session.
 - Sets session name via `pi.setSessionName()`.

--- a/packages/pi-title/package.json
+++ b/packages/pi-title/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@piotr-oles/pi-title",
+  "version": "0.1.0",
+  "description": "Pi Agent extension: generate a short session title from the first user message",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piotr-oles/pi-extensions.git",
+    "directory": "packages/pi-title"
+  },
+  "keywords": [
+    "pi-package"
+  ],
+  "type": "module",
+  "files": [
+    "src",
+    "!src/*.test.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "biome ci src/",
+    "fix": "biome check --write src/",
+    "release": "semantic-release -e semantic-release-monorepo"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-agent-core": "^0.75.5",
+    "@earendil-works/pi-ai": "^0.75.5",
+    "@earendil-works/pi-coding-agent": "^0.75.5",
+    "@marcfargas/pi-test-harness": "^0.6.1",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.1"
+  }
+}

--- a/packages/pi-title/src/index.test.ts
+++ b/packages/pi-title/src/index.test.ts
@@ -120,6 +120,45 @@ describe("pi-title", { timeout: 30_000 }, () => {
     });
   });
 
+  describe("complete() call arguments", () => {
+    it("sends system prompt with user message on first turn", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+
+      const content0 = mockComplete.mock.calls[0][1].messages[0].content[0] as { text: string };
+      const { text } = content0;
+      expect(text).toMatchInlineSnapshot(`
+        "You are naming a conversation session. Based on the user message below, produce a single short title (max 40 characters, no quotes). Be specific — mention the main topic. Use sentence case.
+        <user_messages>
+        Add dark mode toggle to the user settings page with system preference detection
+        </user_messages>"
+      `);
+    });
+
+    it("includes accumulated prompts and previous title on subsequent turn", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when("short msg", [says("Done.")]));
+      await vi.waitFor(() => expect(sessionName()).toBe("Generated title"));
+
+      mockComplete.mockClear();
+      await t.run(when("another msg", [says("Done.")]));
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+
+      const content1 = mockComplete.mock.calls[0][1].messages[0].content[0] as { text: string };
+      const { text } = content1;
+      expect(text).toMatchInlineSnapshot(`
+        "You are naming a conversation session. Based on the user message below, produce a single short title (max 40 characters, no quotes). Be specific — mention the main topic. Use sentence case.
+        <user_messages>
+        short msg
+
+        another msg
+        </user_messages>
+        The current title is "Generated title" — refine it if you now have better context, otherwise keep it."
+      `);
+    });
+  });
+
   describe("/title command", () => {
     it("is registered on extension load", async () => {
       t = await createTestSession({ extensionFactories: [piTitle] });

--- a/packages/pi-title/src/index.test.ts
+++ b/packages/pi-title/src/index.test.ts
@@ -130,9 +130,8 @@ describe("pi-title", { timeout: 30_000 }, () => {
       const { text } = content0;
       expect(text).toMatchInlineSnapshot(`
         "You are naming a conversation session. Based on the user message below, produce a single short title (max 40 characters, no quotes). Be specific — mention the main topic. Use sentence case.
-        <user_messages>
-        Add dark mode toggle to the user settings page with system preference detection
-        </user_messages>"
+        User messages:
+        <message>Add dark mode toggle to the user settings page with system preference detection</message>"
       `);
     });
 
@@ -149,11 +148,10 @@ describe("pi-title", { timeout: 30_000 }, () => {
       const { text } = content1;
       expect(text).toMatchInlineSnapshot(`
         "You are naming a conversation session. Based on the user message below, produce a single short title (max 40 characters, no quotes). Be specific — mention the main topic. Use sentence case.
-        <user_messages>
-        short msg
+        User messages:
+        <message>short msg</message>
+        <message>another msg</message>
 
-        another msg
-        </user_messages>
         The current title is "Generated title" — refine it if you now have better context, otherwise keep it."
       `);
     });

--- a/packages/pi-title/src/index.test.ts
+++ b/packages/pi-title/src/index.test.ts
@@ -1,0 +1,221 @@
+import { createTestSession, says, type TestSession, when } from "@marcfargas/pi-test-harness";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import piTitle, { MAX_TITLE_LENGTH, MIN_PROMPT_LENGTH } from "./index.js";
+
+vi.mock("@earendil-works/pi-ai", () => ({
+  complete: vi.fn(),
+}));
+
+import { complete } from "@earendil-works/pi-ai";
+
+const mockComplete = vi.mocked(complete);
+
+// 82 chars — above MAX_TITLE_LENGTH (40) and MIN_PROMPT_LENGTH (60)
+const LONG_MESSAGE =
+  "Add dark mode toggle to the user settings page with system preference detection";
+// Exactly at MAX_TITLE_LENGTH — sets hasNamed after one turn
+const THRESHOLD_MESSAGE = "A".repeat(MAX_TITLE_LENGTH);
+
+function fakeTitle(text: string) {
+  return {
+    role: "assistant" as const,
+    timestamp: Date.now(),
+    content: [{ type: "text" as const, text }],
+  } as any;
+}
+
+describe("pi-title", { timeout: 30_000 }, () => {
+  let t: TestSession;
+
+  beforeEach(() => {
+    mockComplete.mockResolvedValue(fakeTitle("Generated title"));
+  });
+
+  afterEach(() => {
+    t?.dispose();
+    vi.clearAllMocks();
+  });
+
+  function sessionName() {
+    return t.session.sessionManager.getSessionName() as string | undefined;
+  }
+
+  function registeredCommand(name: string) {
+    return t.session.extensionRunner.getRegisteredCommands().find((cmd: any) => cmd.name === name);
+  }
+
+  async function runCommand(name: string, args = "") {
+    const cmd = registeredCommand(name);
+    if (!cmd) {
+      throw new Error(`Command "${name}" not registered`);
+    }
+    const ctx = t.session.extensionRunner.createCommandContext();
+    return cmd.handler(args, ctx);
+  }
+
+  describe("auto-generation", () => {
+    it("sets session name on first turn", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+
+      await vi.waitFor(() => expect(sessionName()).toBe("Generated title"));
+    });
+
+    it("generates on every turn while prompt length stays below threshold", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+
+      await t.run(when("hi", [says("Hello!")]), when("thanks", [says("Done.")]));
+
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledTimes(2));
+    });
+
+    it("stops generating once prompt length reaches MAX_TITLE_LENGTH", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+
+      await t.run(when(THRESHOLD_MESSAGE, [says("Done.")]), when(LONG_MESSAGE, [says("Done.")]));
+
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+      expect(mockComplete).toHaveBeenCalledOnce();
+    });
+
+    it("strips quotes from generated title", async () => {
+      mockComplete.mockResolvedValue(fakeTitle('"Add dark mode"'));
+
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+
+      await vi.waitFor(() => expect(sessionName()).toBe("Add dark mode"));
+    });
+
+    it(`truncates title to ${MAX_TITLE_LENGTH} characters`, async () => {
+      mockComplete.mockResolvedValue(fakeTitle("A".repeat(80)));
+
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+
+      await vi.waitFor(() => expect(sessionName()).toBeDefined());
+      expect(sessionName()!.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    });
+
+    it("does not set name when model returns empty text", async () => {
+      mockComplete.mockResolvedValue(fakeTitle("   "));
+
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+      expect(sessionName()).toBeUndefined();
+    });
+
+    it("does not crash and shows notification when model errors", async () => {
+      mockComplete.mockRejectedValue(new Error("network failure"));
+
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+      expect(sessionName()).toBeUndefined();
+      expect(t.events.uiCallsFor("notify").length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("/title command", () => {
+    it("is registered on extension load", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+
+      expect(registeredCommand("title")).toBeDefined();
+    });
+
+    it("throws when no prompts have been collected", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+
+      await expect(runCommand("title")).rejects.toThrow(/no prompts/i);
+      expect(mockComplete).not.toHaveBeenCalled();
+    });
+
+    it("sets session name from prompts collected before command invocation", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+
+      mockComplete.mockClear();
+      mockComplete.mockResolvedValue(fakeTitle("Regenerated title"));
+
+      await runCommand("title");
+
+      expect(sessionName()).toBe("Regenerated title");
+    });
+
+    it("notifies with success message after setting name", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+
+      mockComplete.mockClear();
+      mockComplete.mockResolvedValue(fakeTitle("My title"));
+
+      await runCommand("title");
+
+      const notifyCalls = t.events.uiCallsFor("notify");
+      expect(notifyCalls.at(-1)?.args[0]).toMatch(/My title/);
+    });
+
+    it("throws when model returns empty title", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+
+      mockComplete.mockClear();
+      mockComplete.mockResolvedValue(fakeTitle("   "));
+
+      await expect(runCommand("title")).rejects.toThrow(/empty/i);
+    });
+
+    it("throws when model errors", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when(LONG_MESSAGE, [says("Done.")]));
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+
+      mockComplete.mockClear();
+      mockComplete.mockRejectedValue(new Error("network failure"));
+
+      await expect(runCommand("title")).rejects.toThrow("network failure");
+    });
+
+    it("prevents further auto-generation after command success", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when("hi", [says("Hello.")]));
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+
+      mockComplete.mockClear();
+      mockComplete.mockResolvedValue(fakeTitle("Command title"));
+      await runCommand("title");
+      expect(sessionName()).toBe("Command title");
+
+      mockComplete.mockClear();
+      await t.run(when("another message", [says("Done.")]));
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockComplete).not.toHaveBeenCalled();
+    });
+
+    it("uses only recent prompts — enough to meet MIN_PROMPT_LENGTH", async () => {
+      const longPrompt = "I want to refactor the UserService to use the repository pattern";
+      expect(longPrompt.length).toBeGreaterThanOrEqual(MIN_PROMPT_LENGTH);
+
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(
+        when("hi", [says("Hello!")]),
+        when("thanks", [says("Sure!")]),
+        when(longPrompt, [says("Done.")]),
+      );
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalled());
+
+      mockComplete.mockClear();
+      mockComplete.mockResolvedValue(fakeTitle("Refactor UserService"));
+      await runCommand("title");
+
+      expect(sessionName()).toBe("Refactor UserService");
+    });
+  });
+});

--- a/packages/pi-title/src/index.ts
+++ b/packages/pi-title/src/index.ts
@@ -98,7 +98,8 @@ export default function piTitle(pi: ExtensionAPI) {
       }
     })();
 
-    if (userPrompt.length >= MAX_TITLE_LENGTH) {
+    const totalLength = userPrompts.reduce((sum, p) => sum + p.length, 0);
+    if (totalLength >= MAX_TITLE_LENGTH) {
       state.hasNamed = true;
     }
   });

--- a/packages/pi-title/src/index.ts
+++ b/packages/pi-title/src/index.ts
@@ -1,0 +1,144 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { generateSessionTitle } from "./title.js";
+
+export const MAX_TITLE_LENGTH = 40;
+export const MIN_PROMPT_LENGTH = 60;
+
+interface SessionTitleState {
+  hasNamed: boolean;
+  currentTitle: string | undefined;
+  autoGenController: AbortController | null;
+  cmdController: AbortController | null;
+}
+
+function createSessionState(): SessionTitleState {
+  return {
+    hasNamed: false,
+    currentTitle: undefined,
+    autoGenController: null,
+    cmdController: null,
+  };
+}
+
+export default function piTitle(pi: ExtensionAPI) {
+  const state = createSessionState();
+
+  pi.registerCommand("title", {
+    description: "Regenerate session title from recent prompts",
+    handler: async (_args: string, ctx: ExtensionCommandContext) => {
+      const userPrompts = getRecentUserPrompts(ctx, MIN_PROMPT_LENGTH);
+
+      if (userPrompts.length === 0) {
+        throw new Error("No prompts yet — can't generate title.");
+      }
+
+      state.autoGenController?.abort();
+      state.cmdController?.abort();
+      state.cmdController = new AbortController();
+      const { signal } = state.cmdController;
+
+      try {
+        const title = await generateSessionTitle({
+          userPrompts,
+          maxLength: MAX_TITLE_LENGTH,
+          model: getModel(ctx),
+          signal,
+          previousTitle: state.currentTitle,
+        });
+        if (!title) {
+          throw new Error("Model returned empty title.");
+        }
+        state.currentTitle = title;
+        pi.setSessionName(title);
+        ctx.ui.notify(`Title set: "${title}"`);
+        state.hasNamed = true;
+      } catch (error) {
+        if (!signal.aborted) {
+          throw error;
+        }
+      }
+    },
+  });
+
+  pi.on("before_agent_start", (event, ctx) => {
+    const userPrompt = event.prompt.trim();
+    if (!userPrompt || state.hasNamed) {
+      return;
+    }
+
+    const userPrompts = [...getRecentUserPrompts(ctx, MIN_PROMPT_LENGTH), userPrompt];
+
+    state.autoGenController?.abort();
+    state.autoGenController = new AbortController();
+    const { signal } = state.autoGenController;
+    void (async () => {
+      try {
+        const title = await generateSessionTitle({
+          userPrompts,
+          maxLength: MAX_TITLE_LENGTH,
+          model: getModel(ctx),
+          signal,
+          previousTitle: state.currentTitle,
+        });
+        if (title) {
+          state.currentTitle = title;
+          pi.setSessionName(title);
+        }
+      } catch (error) {
+        if (!signal.aborted) {
+          ctx.ui.notify(
+            `Couldn't auto-generate session title: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+    })();
+
+    if (userPrompt.length >= MAX_TITLE_LENGTH) {
+      state.hasNamed = true;
+    }
+  });
+}
+
+function getModel(ctx: ExtensionContext): Model<Api> {
+  const model = ctx.model;
+  if (!model) {
+    throw new Error("No model in the context.");
+  }
+  return model;
+}
+
+function getRecentUserPrompts(ctx: ExtensionContext, minLength: number): string[] {
+  const entries = ctx.sessionManager.getEntries();
+  const recent: string[] = [];
+  let total = 0;
+
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.type !== "message" || entry.message.role !== "user") {
+      continue;
+    }
+
+    const text =
+      typeof entry.message.content === "string"
+        ? entry.message.content
+        : entry.message.content
+            .filter((content) => content.type === "text")
+            .map((content) => content.text)
+            .join("\n");
+
+    if (text) {
+      recent.push(text);
+      total += text.length;
+      if (total >= minLength) {
+        break;
+      }
+    }
+  }
+
+  return recent.reverse();
+}

--- a/packages/pi-title/src/title.ts
+++ b/packages/pi-title/src/title.ts
@@ -1,0 +1,57 @@
+import { type Api, complete, type Model } from "@earendil-works/pi-ai";
+
+interface GenerateSessionTitleParams {
+  userPrompts: string[];
+  maxLength: number;
+  model: Model<Api>;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+  previousTitle?: string;
+}
+
+export async function generateSessionTitle({
+  userPrompts,
+  maxLength,
+  model,
+  signal,
+  previousTitle,
+}: GenerateSessionTitleParams): Promise<string | undefined> {
+  const response = await complete(
+    model,
+    {
+      messages: [
+        {
+          role: "user" as const,
+          timestamp: Date.now(),
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                `You are naming a conversation session. Based on the user message below, produce a single short title (max ${maxLength} characters, no quotes). Be specific — mention the main topic. Use sentence case.`,
+                "<user_messages>",
+                userPrompts.join("\n\n"),
+                "</user_messages>",
+                previousTitle
+                  ? `The current title is "${previousTitle}" — refine it if you now have better context, otherwise keep it.`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join("\n"),
+            },
+          ],
+        },
+      ],
+    },
+    { signal },
+  );
+
+  const title = response.content
+    .filter((content) => content.type === "text")
+    .map((content) => content.text.trim())
+    .join("")
+    .slice(0, maxLength)
+    .replace(/["']/g, "");
+
+  return title || undefined;
+}

--- a/packages/pi-title/src/title.ts
+++ b/packages/pi-title/src/title.ts
@@ -29,11 +29,11 @@ export async function generateSessionTitle({
               type: "text" as const,
               text: [
                 `You are naming a conversation session. Based on the user message below, produce a single short title (max ${maxLength} characters, no quotes). Be specific — mention the main topic. Use sentence case.`,
-                "<user_messages>",
-                userPrompts.join("\n\n"),
-                "</user_messages>",
+                "",
+                "User messages:",
+                ...userPrompts.map((userPrompt) => `<message>${userPrompt}</message>`),
                 previousTitle
-                  ? `The current title is "${previousTitle}" — refine it if you now have better context, otherwise keep it.`
+                  ? `\nThe current title is "${previousTitle}" — refine it if you now have better context, otherwise keep it.`
                   : null,
               ]
                 .filter(Boolean)

--- a/packages/pi-title/tsconfig.json
+++ b/packages/pi-title/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/pi-title/vitest.config.ts
+++ b/packages/pi-title/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,27 @@ importers:
         specifier: ^3.2.1
         version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
 
+  packages/pi-title:
+    devDependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@marcfargas/pi-test-harness':
+        specifier: ^0.6.1
+        version: 0.6.1(@earendil-works/pi-agent-core@0.75.5(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-ai@0.75.5(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.75.5(ws@8.21.0)(zod@4.4.3))
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
+
 packages:
 
   '@actions/core@3.0.1':


### PR DESCRIPTION
Adds `@piotr-oles/pi-title` extension that auto-generates a short session title from user messages.

## What it does
- Hooks `before_agent_start`, accumulates recent user prompts, calls active model in background
- Sets session name via `pi.setSessionName()` — no added latency
- Title locks after first prompt ≥ 40 chars (long enough to be specific)
- `/title` command to manually regenerate from recent session context
- Max title length: 40 chars

## Docs
- Package `README.md` with behavior, examples, and dev instructions
- `AGENTS.md` updated with accurate description (no fake flags)