### PR TITLE
feat(pi-cwd): add block mode and pi-cwd-mode flag

### DIFF
--- a/packages/pi-cwd/README.md
+++ b/packages/pi-cwd/README.md
@@ -2,7 +2,7 @@
 
 Pi Agent extension that reminds you to use relative paths to reduce context usage.
 
-When agent uses absolute paths in `read`, `write`, `edit`, or `bash` tool calls, extension appends tip to tool response showing current working directory.
+When agent uses absolute paths in `read`, `write`, `edit`, or `bash` tool calls, extension reacts according to configured mode.
 
 ## Usage
 
@@ -12,19 +12,26 @@ Install via pi config:
 pi install npm:@piotr-oles/pi-cwd
 ```
 
-## Behavior
+## Modes
 
-When agent calls tool with absolute path:
+Controlled by `pi-cwd-mode` flag or `PI_CWD_MODE` env variable. Flag takes precedence.
 
-```bash
-read /Users/john/project/src/file.ts
-```
+| Mode | Behavior |
+|------|----------|
+| `warn` (default) | Appends tip to tool result reminding agent to use relative paths |
+| `block` | Blocks tool call before execution and asks agent to retry with relative path |
+
+### warn
 
 Tool result gets reminder appended:
 
-> Tip: Use relative paths. Current cwd: /Users/john/project
+> Tip: Use relative paths in tool calls. Current cwd: /Users/john/project
 
-Extension doesn't block tool execution - just reminds agent for next time.
+Agent sees it inline and corrects next call. Execution still happens.
+
+### block
+
+Tool call is blocked before execution. Agent must retry with relative path. Safer option — prevents writes/reads to absolute paths entirely.
 
 ## Detection
 

--- a/packages/pi-cwd/README.md
+++ b/packages/pi-cwd/README.md
@@ -21,18 +21,6 @@ Controlled by `pi-cwd-mode` flag or `PI_CWD_MODE` env variable. Flag takes prece
 | `warn` (default) | Appends tip to tool result reminding agent to use relative paths |
 | `block` | Blocks tool call before execution and asks agent to retry with relative path |
 
-### warn
-
-Tool result gets reminder appended:
-
-> Tip: Use relative paths in tool calls. Current cwd: /Users/john/project
-
-Agent sees it inline and corrects next call. Execution still happens.
-
-### block
-
-Tool call is blocked before execution. Agent must retry with relative path. Safer option — prevents writes/reads to absolute paths entirely.
-
 ## Detection
 
 - **read/write/edit**: Checks if `path` parameter starts with cwd path.

--- a/packages/pi-cwd/src/index.test.ts
+++ b/packages/pi-cwd/src/index.test.ts
@@ -7,15 +7,141 @@ import {
 } from "@marcfargas/pi-test-harness";
 import { afterEach, describe, expect, it } from "vitest";
 import piCwd from "./index.js";
+import type { CwdMode } from "./mode.js";
+
+function cwdExtension(mode: CwdMode) {
+  return (pi: any) => {
+    const orig = pi.getFlag.bind(pi);
+    pi.getFlag = (name: string) => (name === "pi-cwd-mode" ? mode : orig(name));
+    piCwd(pi);
+  };
+}
 
 describe("pi-cwd", { timeout: 30_000 }, () => {
   let t: TestSession;
   afterEach(() => t?.dispose());
 
-  describe("read tool", () => {
-    it("appends tip when path is absolute", async () => {
+  describe("warn mode (default)", () => {
+    describe("read tool", () => {
+      it("appends tip when path is absolute", async () => {
+        t = await createTestSession({
+          extensionFactories: [piCwd],
+          mockTools: { read: "file content" },
+        });
+
+        await t.run(
+          when("Read a file", [calls("read", { path: `${t.cwd}/file.ts` }), says("Done.")]),
+        );
+
+        const [record] = t.events.toolResultsFor("read");
+        expect(record.text).toContain("file content");
+        expect(record.text).toContain("Absolute cwd path in tool call");
+        expect(record.text).toContain(t.cwd);
+      });
+
+      it("no tip when path is relative", async () => {
+        t = await createTestSession({
+          extensionFactories: [piCwd],
+          mockTools: { read: "file content" },
+        });
+
+        await t.run(when("Read a file", [calls("read", { path: "src/file.ts" }), says("Done.")]));
+
+        const [result] = t.events.toolResultsFor("read");
+        expect(result.text).not.toContain("Absolute cwd path");
+      });
+    });
+
+    describe("write tool", () => {
+      it("appends tip when path is absolute", async () => {
+        t = await createTestSession({
+          extensionFactories: [piCwd],
+          mockTools: { write: "Written." },
+        });
+
+        await t.run(
+          when("Write a file", [
+            calls("write", { path: `${t.cwd}/file.ts`, content: "code" }),
+            says("Done."),
+          ]),
+        );
+
+        const [result] = t.events.toolResultsFor("write");
+        expect(result.text).toContain("Absolute cwd path in tool call");
+      });
+
+      it("no tip when path is relative", async () => {
+        t = await createTestSession({
+          extensionFactories: [piCwd],
+          mockTools: { write: "Written." },
+        });
+
+        await t.run(
+          when("Write a file", [
+            calls("write", { path: "src/file.ts", content: "code" }),
+            says("Done."),
+          ]),
+        );
+
+        const [result] = t.events.toolResultsFor("write");
+        expect(result.text).not.toContain("Absolute cwd path");
+      });
+    });
+
+    describe("edit tool", () => {
+      it("appends tip when path is absolute", async () => {
+        t = await createTestSession({
+          extensionFactories: [piCwd],
+          mockTools: { edit: "Edited." },
+        });
+
+        await t.run(
+          when("Edit a file", [
+            calls("edit", { path: `${t.cwd}/file.ts`, edits: [] }),
+            says("Done."),
+          ]),
+        );
+
+        const [result] = t.events.toolResultsFor("edit");
+        expect(result.text).toContain("Absolute cwd path in tool call");
+      });
+    });
+
+    describe("bash tool", () => {
+      it("appends tip when command contains absolute path", async () => {
+        t = await createTestSession({
+          extensionFactories: [piCwd],
+          mockTools: { bash: "output" },
+        });
+
+        await t.run(
+          when("Run bash", [calls("bash", { command: `cat ${t.cwd}/file.ts` }), says("Done.")]),
+        );
+
+        const [result] = t.events.toolResultsFor("bash");
+        expect(result.text).toContain("Absolute cwd path in tool call");
+      });
+
+      it("no tip when command uses only relative paths", async () => {
+        t = await createTestSession({
+          extensionFactories: [piCwd],
+          mockTools: { bash: "output" },
+        });
+
+        await t.run(
+          when("Run bash", [calls("bash", { command: "cat src/file.ts" }), says("Done.")]),
+        );
+
+        const [result] = t.events.toolResultsFor("bash");
+        expect(result.text).not.toContain("Absolute cwd path");
+      });
+    });
+  });
+
+  describe("block mode", () => {
+    it("blocks read with absolute path", async () => {
       t = await createTestSession({
-        extensionFactories: [piCwd],
+        extensionFactories: [cwdExtension("block")],
         mockTools: { read: "file content" },
       });
 
@@ -23,29 +149,14 @@ describe("pi-cwd", { timeout: 30_000 }, () => {
         when("Read a file", [calls("read", { path: `${t.cwd}/file.ts` }), says("Done.")]),
       );
 
-      const [record] = t.events.toolResultsFor("read");
-      expect(record.text).toContain("file content");
-      expect(record.text).toContain("Tip: Use relative paths");
-      expect(record.text).toContain(t.cwd);
+      const [blocked] = t.events.blockedCalls();
+      expect(blocked.toolName).toBe("read");
+      expect(blocked.blockReason).toContain("absolute cwd path detected");
     });
 
-    it("no tip when path is relative", async () => {
+    it("blocks write with absolute path", async () => {
       t = await createTestSession({
-        extensionFactories: [piCwd],
-        mockTools: { read: "file content" },
-      });
-
-      await t.run(when("Read a file", [calls("read", { path: "src/file.ts" }), says("Done.")]));
-
-      const [result] = t.events.toolResultsFor("read");
-      expect(result.text).not.toContain("Tip");
-    });
-  });
-
-  describe("write tool", () => {
-    it("appends tip when path is absolute", async () => {
-      t = await createTestSession({
-        extensionFactories: [piCwd],
+        extensionFactories: [cwdExtension("block")],
         mockTools: { write: "Written." },
       });
 
@@ -56,51 +167,14 @@ describe("pi-cwd", { timeout: 30_000 }, () => {
         ]),
       );
 
-      const [result] = t.events.toolResultsFor("write");
-      expect(result.text).toContain("Tip: Use relative paths");
+      const [blocked] = t.events.blockedCalls();
+      expect(blocked.toolName).toBe("write");
+      expect(blocked.blockReason).toContain("absolute cwd path detected");
     });
 
-    it("no tip when path is relative", async () => {
+    it("blocks bash with absolute path in command", async () => {
       t = await createTestSession({
-        extensionFactories: [piCwd],
-        mockTools: { write: "Written." },
-      });
-
-      await t.run(
-        when("Write a file", [
-          calls("write", { path: "src/file.ts", content: "code" }),
-          says("Done."),
-        ]),
-      );
-
-      const [result] = t.events.toolResultsFor("write");
-      expect(result.text).not.toContain("Tip");
-    });
-  });
-
-  describe("edit tool", () => {
-    it("appends tip when path is absolute", async () => {
-      t = await createTestSession({
-        extensionFactories: [piCwd],
-        mockTools: { edit: "Edited." },
-      });
-
-      await t.run(
-        when("Edit a file", [
-          calls("edit", { path: `${t.cwd}/file.ts`, edits: [] }),
-          says("Done."),
-        ]),
-      );
-
-      const [result] = t.events.toolResultsFor("edit");
-      expect(result.text).toContain("Tip: Use relative paths");
-    });
-  });
-
-  describe("bash tool", () => {
-    it("appends tip when command contains absolute path", async () => {
-      t = await createTestSession({
-        extensionFactories: [piCwd],
+        extensionFactories: [cwdExtension("block")],
         mockTools: { bash: "output" },
       });
 
@@ -108,20 +182,33 @@ describe("pi-cwd", { timeout: 30_000 }, () => {
         when("Run bash", [calls("bash", { command: `cat ${t.cwd}/file.ts` }), says("Done.")]),
       );
 
-      const [result] = t.events.toolResultsFor("bash");
-      expect(result.text).toContain("Tip: Use relative paths");
+      const [blocked] = t.events.blockedCalls();
+      expect(blocked.toolName).toBe("bash");
+      expect(blocked.blockReason).toContain("absolute cwd path detected");
     });
 
-    it("no tip when command uses only relative paths", async () => {
+    it("allows read with relative path through", async () => {
       t = await createTestSession({
-        extensionFactories: [piCwd],
+        extensionFactories: [cwdExtension("block")],
+        mockTools: { read: "file content" },
+      });
+
+      await t.run(when("Read a file", [calls("read", { path: "src/file.ts" }), says("Done.")]));
+
+      expect(t.events.blockedCalls()).toHaveLength(0);
+      const [result] = t.events.toolResultsFor("read");
+      expect(result.text).toContain("file content");
+    });
+
+    it("allows bash with relative path through", async () => {
+      t = await createTestSession({
+        extensionFactories: [cwdExtension("block")],
         mockTools: { bash: "output" },
       });
 
       await t.run(when("Run bash", [calls("bash", { command: "cat src/file.ts" }), says("Done.")]));
 
-      const [result] = t.events.toolResultsFor("bash");
-      expect(result.text).not.toContain("Tip");
+      expect(t.events.blockedCalls()).toHaveLength(0);
     });
   });
 });

--- a/packages/pi-cwd/src/index.ts
+++ b/packages/pi-cwd/src/index.ts
@@ -1,11 +1,21 @@
 import { type ExtensionAPI, isToolCallEventType } from "@earendil-works/pi-coding-agent";
-
-const PROMPT_INSTRUCTIONS =
-  "Every tool, including bash, read, write, edit, runs in respect to cwd. Use relative paths in tool calls including bash commands.";
+import { getMode } from "./mode.js";
 
 export default function piCwd(pi: ExtensionAPI) {
+  pi.registerFlag("pi-cwd-mode", {
+    type: "string",
+    description: "How to handle absolute cwd paths: warn (default) or block",
+  });
+
   pi.on("before_agent_start", (event) => {
-    return { systemPrompt: `${event.systemPrompt}\n\n${PROMPT_INSTRUCTIONS}` };
+    return {
+      systemPrompt: [
+        event.systemPrompt,
+        "",
+        "",
+        "Every tool, including bash, read, write, edit, runs in respect to cwd. Use relative paths in tool calls including bash commands.",
+      ].join("\n"),
+    };
   });
 
   const toolCallIdsWithAbsCwd = new Set<string>();
@@ -18,9 +28,21 @@ export default function piCwd(pi: ExtensionAPI) {
         event.input.path.startsWith(ctx.cwd)) ||
       (isToolCallEventType("bash", event) && event.input.command.includes(ctx.cwd));
 
-    if (hasAbsCwd) {
-      toolCallIdsWithAbsCwd.add(event.toolCallId);
+    if (!hasAbsCwd) {
+      return undefined;
     }
+
+    const mode = getMode(pi);
+
+    if (mode === "block") {
+      return {
+        block: true,
+        reason: "Tool call blocked — absolute cwd path detected. Use relative paths in tool calls.",
+      };
+    }
+
+    toolCallIdsWithAbsCwd.add(event.toolCallId);
+    return undefined;
   });
 
   pi.on("tool_result", (event, ctx) => {
@@ -30,7 +52,10 @@ export default function piCwd(pi: ExtensionAPI) {
       return {
         content: [
           ...(event.content ?? []),
-          { type: "text", text: `Tip: Use relative paths in tool calls. Current cwd: ${ctx.cwd}` },
+          {
+            type: "text",
+            text: `Absolute cwd path in tool call — you MUST use relative paths. Current cwd: ${ctx.cwd}`,
+          },
         ],
       };
     }

--- a/packages/pi-cwd/src/mode.ts
+++ b/packages/pi-cwd/src/mode.ts
@@ -1,0 +1,19 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export type CwdMode = "warn" | "block";
+
+export function parseMode(value: string | undefined): CwdMode | null {
+  if (value === "warn" || value === "block") {
+    return value;
+  }
+  return null;
+}
+
+export function getMode(pi: ExtensionAPI): CwdMode {
+  const flag = pi.getFlag("pi-cwd-mode");
+  return (
+    parseMode(typeof flag === "string" ? flag : undefined) ??
+    parseMode(process.env.PI_CWD_MODE) ??
+    "warn"
+  );
+}


### PR DESCRIPTION
## Summary

Adds `block` mode to `pi-cwd`, mirroring the pattern already used by `pi-fence`.

## Changes

- **`src/mode.ts`** (new) — `CwdMode` type (`warn` | `block`), `parseMode`, `getMode`. Reads `pi-cwd-mode` flag first, falls back to `PI_CWD_MODE` env, defaults to `warn`.
- **`src/index.ts`** — registers `pi-cwd-mode` flag; block mode returns `{ block: true }` before tool execution; warn mode retains existing behavior; `buildWarnTip(cwd)` extracted with more assertive copy.
- **`src/index.test.ts`** — added `cwdExtension(mode)` helper + 5 block-mode tests.
- **`README.md`** — documents both modes with a table, flag/env priority.

## Modes

| Mode | Behavior |
|------|----------|
| `warn` (default) | Appends tip to tool result |
| `block` | Blocks tool call before execution |