### PR TITLE
fix(pi-title): derive title lock state from session to fix /new

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ The `subagent:templates` command opens an interactive terminal menu listing all 
 ### `pi-title` (`packages/pi-title`)
 Generates short session title from user messages. Hooks `before_agent_start`, accumulates recent user prompts, calls `complete()` with active model in background (non-blocking), sets name via `pi.setSessionName()`. Title locks once total accumulated user prompt content (current + previous messages) reaches 40 chars. Max title length: 40 chars.
 
+Lock state is derived from the session, not in-memory closure state: when the title locks, a `custom` session entry (`customType: "pi-title"`) is persisted via `pi.appendEntry()`. "Already named?" is recomputed each turn by scanning `ctx.sessionManager.getEntries()` for that entry, so `/new`, `/resume`, and `/fork` reset cleanly (a fresh session has no marker) without leaking title state across sessions. `previousTitle` (for refinement) is read from `pi.getSessionName()`. A `session_shutdown` handler aborts in-flight generation so a late title never lands in the next session.
+
 Exposes `/title` command to manually regenerate title from recent session context.
 
 No flags — constants are hardcoded (`MAX_TITLE_LENGTH = 40`, `MIN_PROMPT_LENGTH = 60`).

--- a/packages/pi-title/src/index.test.ts
+++ b/packages/pi-title/src/index.test.ts
@@ -1,6 +1,6 @@
 import { createTestSession, says, type TestSession, when } from "@marcfargas/pi-test-harness";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import piTitle, { MAX_TITLE_LENGTH, MIN_PROMPT_LENGTH } from "./index.js";
+import piTitle, { MAX_TITLE_LENGTH, MIN_PROMPT_LENGTH, PI_TITLE_CUSTOM_TYPE } from "./index.js";
 
 vi.mock("@earendil-works/pi-ai", () => ({
   complete: vi.fn(),
@@ -38,6 +38,12 @@ describe("pi-title", { timeout: 30_000 }, () => {
 
   function sessionName() {
     return t.session.sessionManager.getSessionName() as string | undefined;
+  }
+
+  function lockEntries() {
+    return t.session.sessionManager
+      .getEntries()
+      .filter((e: any) => e.type === "custom" && e.customType === PI_TITLE_CUSTOM_TYPE);
   }
 
   function registeredCommand(name: string) {
@@ -79,6 +85,24 @@ describe("pi-title", { timeout: 30_000 }, () => {
       expect(mockComplete).toHaveBeenCalledOnce();
     });
 
+    it("persists a lock marker once prompt length reaches MAX_TITLE_LENGTH", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+
+      await t.run(when(THRESHOLD_MESSAGE, [says("Done.")]));
+
+      await vi.waitFor(() => expect(lockEntries().length).toBe(1));
+      expect(lockEntries()[0].data).toEqual({ title: "Generated title" });
+    });
+
+    it("does not persist a lock marker while below threshold", async () => {
+      t = await createTestSession({ extensionFactories: [piTitle] });
+
+      await t.run(when("hi", [says("Hello!")]));
+
+      await vi.waitFor(() => expect(sessionName()).toBe("Generated title"));
+      expect(lockEntries()).toHaveLength(0);
+    });
+
     it("strips quotes from generated title", async () => {
       mockComplete.mockResolvedValue(fakeTitle('"Add dark mode"'));
 
@@ -117,6 +141,30 @@ describe("pi-title", { timeout: 30_000 }, () => {
       await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
       expect(sessionName()).toBeUndefined();
       expect(t.events.uiCallsFor("notify").length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("session_shutdown", () => {
+    it("aborts in-flight generation so a late title never lands", async () => {
+      let resolveComplete: ((value: unknown) => void) | undefined;
+      mockComplete.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveComplete = resolve;
+          }) as any,
+      );
+
+      t = await createTestSession({ extensionFactories: [piTitle] });
+      await t.run(when("hi", [says("Hello!")]));
+      await vi.waitFor(() => expect(mockComplete).toHaveBeenCalledOnce());
+
+      await t.session.extensionRunner.emit({ type: "session_shutdown", reason: "new" });
+
+      resolveComplete?.(fakeTitle("Late title"));
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(sessionName()).toBeUndefined();
+      expect(lockEntries()).toHaveLength(0);
     });
   });
 

--- a/packages/pi-title/src/index.ts
+++ b/packages/pi-title/src/index.ts
@@ -94,10 +94,14 @@ export default function piTitle(pi: ExtensionAPI) {
     const { signal } = state.autoGenController;
     void (async () => {
       try {
+        const model = getModel(ctx);
+        const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
         const title = await generateSessionTitle({
           userPrompts,
           maxLength: MAX_TITLE_LENGTH,
           model: getModel(ctx),
+          apiKey: auth.ok ? auth.apiKey : undefined,
+          headers: auth.ok ? auth.headers : undefined,
           signal,
           previousTitle: pi.getSessionName(),
         });

--- a/packages/pi-title/src/index.ts
+++ b/packages/pi-title/src/index.ts
@@ -8,25 +8,40 @@ import { generateSessionTitle } from "./title.js";
 
 export const MAX_TITLE_LENGTH = 40;
 export const MIN_PROMPT_LENGTH = 60;
+export const PI_TITLE_CUSTOM_TYPE = "pi-title";
 
 interface SessionTitleState {
-  hasNamed: boolean;
-  currentTitle: string | undefined;
   autoGenController: AbortController | null;
   cmdController: AbortController | null;
 }
 
 function createSessionState(): SessionTitleState {
   return {
-    hasNamed: false,
-    currentTitle: undefined,
     autoGenController: null,
     cmdController: null,
   };
 }
 
+/**
+ * Whether pi-title has finished naming the current session. Derived from the
+ * session itself (a persisted custom entry) so it resets automatically on /new,
+ * /resume, and /fork instead of leaking across sessions via closure state.
+ */
+function isLocked(ctx: ExtensionContext): boolean {
+  return ctx.sessionManager
+    .getEntries()
+    .some((entry) => entry.type === "custom" && entry.customType === PI_TITLE_CUSTOM_TYPE);
+}
+
 export default function piTitle(pi: ExtensionAPI) {
   const state = createSessionState();
+
+  pi.on("session_shutdown", () => {
+    state.autoGenController?.abort();
+    state.cmdController?.abort();
+    state.autoGenController = null;
+    state.cmdController = null;
+  });
 
   pi.registerCommand("title", {
     description: "Regenerate session title from recent prompts",
@@ -48,15 +63,14 @@ export default function piTitle(pi: ExtensionAPI) {
           maxLength: MAX_TITLE_LENGTH,
           model: getModel(ctx),
           signal,
-          previousTitle: state.currentTitle,
+          previousTitle: pi.getSessionName(),
         });
         if (!title) {
           throw new Error("Model returned empty title.");
         }
-        state.currentTitle = title;
         pi.setSessionName(title);
+        pi.appendEntry(PI_TITLE_CUSTOM_TYPE, { title });
         ctx.ui.notify(`Title set: "${title}"`);
-        state.hasNamed = true;
       } catch (error) {
         if (!signal.aborted) {
           throw error;
@@ -67,11 +81,13 @@ export default function piTitle(pi: ExtensionAPI) {
 
   pi.on("before_agent_start", (event, ctx) => {
     const userPrompt = event.prompt.trim();
-    if (!userPrompt || state.hasNamed) {
+    if (!userPrompt || isLocked(ctx)) {
       return;
     }
 
     const userPrompts = [...getRecentUserPrompts(ctx, MIN_PROMPT_LENGTH), userPrompt];
+    const totalLength = userPrompts.reduce((sum, p) => sum + p.length, 0);
+    const shouldLock = totalLength >= MAX_TITLE_LENGTH;
 
     state.autoGenController?.abort();
     state.autoGenController = new AbortController();
@@ -83,11 +99,13 @@ export default function piTitle(pi: ExtensionAPI) {
           maxLength: MAX_TITLE_LENGTH,
           model: getModel(ctx),
           signal,
-          previousTitle: state.currentTitle,
+          previousTitle: pi.getSessionName(),
         });
-        if (title) {
-          state.currentTitle = title;
+        if (title && !signal.aborted) {
           pi.setSessionName(title);
+          if (shouldLock) {
+            pi.appendEntry(PI_TITLE_CUSTOM_TYPE, { title });
+          }
         }
       } catch (error) {
         if (!signal.aborted) {
@@ -97,11 +115,6 @@ export default function piTitle(pi: ExtensionAPI) {
         }
       }
     })();
-
-    const totalLength = userPrompts.reduce((sum, p) => sum + p.length, 0);
-    if (totalLength >= MAX_TITLE_LENGTH) {
-      state.hasNamed = true;
-    }
   });
 }
 

--- a/packages/pi-title/src/index.ts
+++ b/packages/pi-title/src/index.ts
@@ -10,37 +10,15 @@ export const MAX_TITLE_LENGTH = 40;
 export const MIN_PROMPT_LENGTH = 60;
 export const PI_TITLE_CUSTOM_TYPE = "pi-title";
 
-interface SessionTitleState {
-  autoGenController: AbortController | null;
-  cmdController: AbortController | null;
-}
-
-function createSessionState(): SessionTitleState {
-  return {
-    autoGenController: null,
-    cmdController: null,
-  };
-}
-
-/**
- * Whether pi-title has finished naming the current session. Derived from the
- * session itself (a persisted custom entry) so it resets automatically on /new,
- * /resume, and /fork instead of leaking across sessions via closure state.
- */
-function isLocked(ctx: ExtensionContext): boolean {
-  return ctx.sessionManager
-    .getEntries()
-    .some((entry) => entry.type === "custom" && entry.customType === PI_TITLE_CUSTOM_TYPE);
-}
-
 export default function piTitle(pi: ExtensionAPI) {
-  const state = createSessionState();
+  let autoGenController: AbortController | null;
+  let cmdController: AbortController | null;
 
   pi.on("session_shutdown", () => {
-    state.autoGenController?.abort();
-    state.cmdController?.abort();
-    state.autoGenController = null;
-    state.cmdController = null;
+    autoGenController?.abort();
+    cmdController?.abort();
+    autoGenController = null;
+    cmdController = null;
   });
 
   pi.registerCommand("title", {
@@ -52,16 +30,19 @@ export default function piTitle(pi: ExtensionAPI) {
         throw new Error("No prompts yet — can't generate title.");
       }
 
-      state.autoGenController?.abort();
-      state.cmdController?.abort();
-      state.cmdController = new AbortController();
-      const { signal } = state.cmdController;
+      autoGenController?.abort();
+      cmdController?.abort();
+      cmdController = new AbortController();
+      const { signal } = cmdController;
 
       try {
+        const { model, apiKey, headers } = await getModel(ctx);
         const title = await generateSessionTitle({
           userPrompts,
           maxLength: MAX_TITLE_LENGTH,
-          model: getModel(ctx),
+          model,
+          apiKey,
+          headers,
           signal,
           previousTitle: pi.getSessionName(),
         });
@@ -89,19 +70,18 @@ export default function piTitle(pi: ExtensionAPI) {
     const totalLength = userPrompts.reduce((sum, p) => sum + p.length, 0);
     const shouldLock = totalLength >= MAX_TITLE_LENGTH;
 
-    state.autoGenController?.abort();
-    state.autoGenController = new AbortController();
-    const { signal } = state.autoGenController;
+    autoGenController?.abort();
+    autoGenController = new AbortController();
+    const { signal } = autoGenController;
     void (async () => {
       try {
-        const model = getModel(ctx);
-        const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+        const { model, apiKey, headers } = await getModel(ctx);
         const title = await generateSessionTitle({
           userPrompts,
           maxLength: MAX_TITLE_LENGTH,
-          model: getModel(ctx),
-          apiKey: auth.ok ? auth.apiKey : undefined,
-          headers: auth.ok ? auth.headers : undefined,
+          model,
+          apiKey,
+          headers,
           signal,
           previousTitle: pi.getSessionName(),
         });
@@ -122,12 +102,22 @@ export default function piTitle(pi: ExtensionAPI) {
   });
 }
 
-function getModel(ctx: ExtensionContext): Model<Api> {
+interface GetModelResult {
+  model: Model<Api>;
+  apiKey?: string;
+  headers?: Record<string, string>;
+}
+async function getModel(ctx: ExtensionContext): Promise<GetModelResult> {
   const model = ctx.model;
   if (!model) {
     throw new Error("No model in the context.");
   }
-  return model;
+  const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+  if (!auth.ok) {
+    throw new Error(`Cannot authenticate the model ${model.provider}/${model.name}.`);
+  }
+
+  return { model, apiKey: auth.apiKey, headers: auth.headers };
 }
 
 function getRecentUserPrompts(ctx: ExtensionContext, minLength: number): string[] {
@@ -159,4 +149,15 @@ function getRecentUserPrompts(ctx: ExtensionContext, minLength: number): string[
   }
 
   return recent.reverse();
+}
+
+/**
+ * Whether pi-title has finished naming the current session. Derived from the
+ * session itself (a persisted custom entry) so it resets automatically on /new,
+ * /resume, and /fork instead of leaking across sessions via closure state.
+ */
+function isLocked(ctx: ExtensionContext): boolean {
+  return ctx.sessionManager
+    .getEntries()
+    .some((entry) => entry.type === "custom" && entry.customType === PI_TITLE_CUSTOM_TYPE);
 }

--- a/packages/pi-title/src/title.ts
+++ b/packages/pi-title/src/title.ts
@@ -14,6 +14,8 @@ export async function generateSessionTitle({
   userPrompts,
   maxLength,
   model,
+  apiKey,
+  headers,
   signal,
   previousTitle,
 }: GenerateSessionTitleParams): Promise<string | undefined> {
@@ -43,7 +45,7 @@ export async function generateSessionTitle({
         },
       ],
     },
-    { signal },
+    { signal, apiKey, headers },
   );
 
   const title = response.content

--- a/packages/pi-title/src/title.ts
+++ b/packages/pi-title/src/title.ts
@@ -4,8 +4,8 @@ interface GenerateSessionTitleParams {
   userPrompts: string[];
   maxLength: number;
   model: Model<Api>;
-  apiKey?: string;
-  headers?: Record<string, string>;
+  apiKey: string | undefined;
+  headers: Record<string, string> | undefined;
   signal?: AbortSignal;
   previousTitle?: string;
 }


### PR DESCRIPTION
## Problem

After `/new`, pi-title did not regenerate the session title — it kept the old session's name and never named the fresh session.

**Root cause:** title lock state (`hasNamed` / `currentTitle`) lived in the extension's closure. On `/new`, `/resume`, and `/fork` pi reuses the loaded extension instances (only `session_shutdown`/`session_start` fire — the factory closure is not recreated), so the stale `hasNamed === true` leaked into the new session and suppressed regeneration. pi-title also had no lifecycle handler to reset.

## Fix

Derive lock state from the **session itself** instead of closure memory:

- On lock, persist a `custom` session entry (`customType: "pi-title"`) via `pi.appendEntry()`.
- Recompute "already named?" each turn by scanning `ctx.sessionManager.getEntries()`. A fresh session has no marker ⇒ starts clean. Resilient to `/new`, `/resume`, `/fork`, reload.
- Read `previousTitle` (for refinement) from `pi.getSessionName()` — pi already persists the name per session.
- Add a `session_shutdown` handler that aborts in-flight generation, plus a `!signal.aborted` guard before `setSessionName`/`appendEntry`, so a late title from the old session never lands in the next one.

## Tests

20/20 pass (typecheck + biome clean). Added:
- lock marker persisted at threshold
- no marker while below threshold
- `session_shutdown` aborts in-flight generation

Harness can't drive a real `/new`, so end-to-end reset is covered by the marker presence/absence tests (a markerless session is inherently unlocked).

## Docs

Updated `AGENTS.md` pi-title section to document the session-entry persistence mechanism.
