### PR TITLE
Show the current branch's GitHub PR status in the footer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Flags:
 - `pi-reflag-ignore-mode` (string, default: `'auto'`) — controls when `--no-ignore` is passed to `fd`: `'auto'` adds it when the search path contains a known ignored directory (node_modules, .venv, .yarn, dist, target, …); `'no-ignore'` always adds it; `'ignore'` never adds it
 
 ### `pi-pr` (`packages/pi-pr`)
-Shows the current branch's GitHub PR in the footer via `ctx.ui.setStatus("pi-pr", …)`: a clickable `#n` link (OSC 8 hyperlink to the PR URL, colored by lifecycle) plus a `●` CI-rollup glyph (always shown, colored by state, `none` dim so its position stays stable) and two conditional glyphs in fixed order: a red `‼` conflict glyph only when the PR has merge conflicts, and a review verdict only when decided (`✓` green approved, `✗` red changes-requested).
+Shows the current branch's GitHub PR in the footer via `ctx.ui.setStatus("pi-pr", …)`: a clickable `#n` link (OSC 8 hyperlink to the PR URL, colored by lifecycle) plus a `●` CI-rollup glyph (always shown, colored by state, `none` dim so its position stays stable) and two conditional glyphs in fixed order: a red `‼` conflict glyph only when the PR has merge conflicts, and a review verdict only when decided (`✓` green approved, `✗` red changes-requested). Polls on a timer and also fires a one-off refresh when a `tool_result` shows the agent ran `gh pr create`, so a newly opened PR shows up immediately.
 
 Flags:
 - `pi-pr-interval` (string numeric, default: `30`) — poll interval in seconds, floored at 5s (registered as a string flag because pi flags are boolean or string only; parsed as a number at use)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,12 @@ Flags:
 - `pi-reflag-verbose` (boolean, default: false) — show a toast with original and rewritten command in the UI
 - `pi-reflag-ignore-mode` (string, default: `'auto'`) — controls when `--no-ignore` is passed to `fd`: `'auto'` adds it when the search path contains a known ignored directory (node_modules, .venv, .yarn, dist, target, …); `'no-ignore'` always adds it; `'ignore'` never adds it
 
+### `pi-pr` (`packages/pi-pr`)
+Shows the current branch's GitHub PR in the footer via `ctx.ui.setStatus("pi-pr", …)`: a clickable `#n` link (OSC 8 hyperlink to the PR URL, colored by lifecycle) plus a `●` CI-rollup glyph (always shown, colored by state, `none` dim so its position stays stable) and two conditional glyphs in fixed order: a red `‼` conflict glyph only when the PR has merge conflicts, and a review verdict only when decided (`✓` green approved, `✗` red changes-requested).
+
+Flags:
+- `pi-pr-interval` (string numeric, default: `30`) — poll interval in seconds, floored at 5s (registered as a string flag because pi flags are boolean or string only; parsed as a number at use)
+
 ## Tech stack
 
 - **Runtime**: Node.js ≥ 22.19.0, ESM throughout (`"type": "module"`)
@@ -192,4 +198,3 @@ Conventional commit format is required and enforced by commitlint (commit-msg ho
 Tag format: `@piotr-oles/<pkg>@<version>`. Each package gets its own `CHANGELOG.md`.
 
 Dry run (no publish, no tags): `pnpm validate:release`
-

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A monorepo of [pi coding agent](https://github.com/earendil-works/pi) extensions
 | [`@piotr-oles/pi-cwd`](packages/pi-cwd) | Reminds agent to use relative paths — detects absolute cwd paths in `read`/`write`/`edit`/`bash` calls and appends a tip to the tool result |
 | [`@piotr-oles/pi-subagents`](packages/pi-subagents) | Lets the agent spawn specialized subagents — each running in its own isolated session with its own model, tools, and instructions |
 | [`@piotr-oles/pi-title`](packages/pi-title) | Generates a short session title from the first user message using the active model |
+| [`@piotr-oles/pi-pr`](packages/pi-pr) | Shows the current branch's GitHub PR in the footer — a clickable `#n` link plus a CI status dot, a merge-conflict alarm, and a review verdict, polled in the background |
 | [`@piotr-oles/pi-yagni`](packages/pi-yagni) | Injects YAGNI discipline into the system prompt — build the minimum that works, reuse before writing, no speculative code |
 
 ## Development

--- a/packages/pi-pr/README.md
+++ b/packages/pi-pr/README.md
@@ -19,7 +19,9 @@ conflict:          model (branch)  …  #123 ●‼✗
 
 On session start (and every poll interval after) it runs `gh pr view` for the
 current branch and renders the result via `ctx.ui.setStatus("pi-pr", …)`, which
-coexists with pi's built-in footer.
+coexists with pi's built-in footer. It also fires a one-off refresh right after
+the agent runs a `gh pr create` bash command, so a freshly opened PR appears in
+the footer without waiting for the next poll tick.
 
 - **`#n`** — the PR number, wrapped in an OSC 8 hyperlink to the PR URL, colored
   by lifecycle: draft = dim, open = default text, merged = muted, closed = error (red).

--- a/packages/pi-pr/README.md
+++ b/packages/pi-pr/README.md
@@ -1,0 +1,78 @@
+# pi-pr
+
+A [pi coding agent](https://github.com/earendil-works/pi) extension that shows
+the current branch's GitHub pull request in the footer: a clickable `#n` link,
+the CI status, a conflict alarm when the PR can't merge cleanly, and the review
+verdict.
+
+
+```
+approved:          model (branch)  …  #123 ●✓
+changes requested: model (branch)  …  #123 ●✗
+review pending:    model (branch)  …  #123 ●
+conflict:          model (branch)  …  #123 ●‼✗
+                                      ^^^^ ^^^
+                                      link indicators
+```
+
+## What it does
+
+On session start (and every poll interval after) it runs `gh pr view` for the
+current branch and renders the result via `ctx.ui.setStatus("pi-pr", …)`, which
+coexists with pi's built-in footer.
+
+- **`#n`** — the PR number, wrapped in an OSC 8 hyperlink to the PR URL, colored
+  by lifecycle: draft = dim, open = default text, merged = muted, closed = error (red).
+- **`●` CI** — aggregated check rollup: success = green, failure = red,
+  running = yellow, none = dim. Always rendered (`none` dim so its position
+  stays stable).
+- **`‼` conflict** — red, shown **only** when the PR has merge conflicts
+  (`clean`/`unknown` merge states render nothing).
+- **review verdict** — shown **only** when a decision exists: `✓` green when
+  approved, `✗` red when changes are requested. `review_required`/`none` render
+  nothing.
+
+Glyphs keep a fixed order: CI, then conflict, then review verdict. Only `●`
+always shows; the conflict and review glyphs appear/disappear with state.
+
+When there is no PR for the branch, the directory is not a GitHub repo, `gh` is
+missing or unauthenticated, or any error occurs, the extension is silent: it
+clears its status and shows nothing.
+
+## Requirements
+
+- The [`gh`](https://cli.github.com/) CLI, authenticated (`gh auth login`).
+- A terminal that supports OSC 8 hyperlinks for the clickable `#n` (plain text
+  otherwise — no breakage).
+
+## Command
+
+- **`/pr`** — open the current branch's PR in the browser (`gh pr view --web`)
+  and force an immediate status refresh.
+
+## Flags
+
+- `pi-pr-interval` (default `30`) — poll interval in seconds. Floored at 5s to
+  avoid abuse and API rate limits. (Registered as a string flag because pi flags
+  are boolean or string only; the value is parsed as a number at use.)
+
+## Notes
+
+- Polling uses a fixed `setInterval` with an overlap guard, so a slow `gh` call
+  never piles up. A branch switch is reflected within one interval; `/pr` forces
+  an immediate refresh.
+
+## Development
+
+```bash
+pnpm install
+pnpm test
+pnpm typecheck
+pnpm check
+```
+
+To test changes manually:
+
+```bash
+pi -e packages/pi-pr/src/index.ts
+```

--- a/packages/pi-pr/package.json
+++ b/packages/pi-pr/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@piotr-oles/pi-pr",
+  "version": "0.1.0",
+  "description": "Pi Agent extension: show the current branch's GitHub PR status (clickable #n + CI/merge/review dots) in the footer",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piotr-oles/pi-extensions.git",
+    "directory": "packages/pi-pr"
+  },
+  "keywords": [
+    "pi-package"
+  ],
+  "type": "module",
+  "files": [
+    "src",
+    "!src/*.test.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "biome ci src/",
+    "fix": "biome check --write src/",
+    "release": "semantic-release -e semantic-release-monorepo"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-agent-core": "^0.75.5",
+    "@earendil-works/pi-ai": "^0.75.5",
+    "@earendil-works/pi-coding-agent": "^0.75.5",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.1"
+  }
+}

--- a/packages/pi-pr/src/command.test.ts
+++ b/packages/pi-pr/src/command.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isPrCreateCommand } from "./command.js";
+
+describe("isPrCreateCommand", () => {
+  it("matches a plain gh pr create", () => {
+    expect(isPrCreateCommand("gh pr create")).toBe(true);
+  });
+
+  it("matches with flags and args", () => {
+    expect(isPrCreateCommand("gh pr create --draft --title x --body-file /tmp/b")).toBe(true);
+  });
+
+  it("matches when chained after another command", () => {
+    expect(isPrCreateCommand("git push -u origin feat/x && gh pr create --fill")).toBe(true);
+  });
+
+  it("matches inside a subshell", () => {
+    expect(isPrCreateCommand("(gh pr create --draft)")).toBe(true);
+  });
+
+  it("does not match other gh pr subcommands", () => {
+    expect(isPrCreateCommand("gh pr view --json number")).toBe(false);
+    expect(isPrCreateCommand("gh pr edit 54 --body-file /tmp/b")).toBe(false);
+    expect(isPrCreateCommand("gh pr list")).toBe(false);
+  });
+
+  it("does not match unrelated commands", () => {
+    expect(isPrCreateCommand("echo gh pr createx")).toBe(false);
+    expect(isPrCreateCommand("gh repo create")).toBe(false);
+    expect(isPrCreateCommand("git commit -m 'gh pr create'")).toBe(false);
+  });
+});

--- a/packages/pi-pr/src/command.ts
+++ b/packages/pi-pr/src/command.ts
@@ -1,0 +1,10 @@
+/**
+ * True when a bash command runs `gh pr create` (possibly chained with `&&`,
+ * `||`, `;`, or pipes, and with any surrounding flags/args).
+ *
+ * Used to trigger a one-off status refresh right after the agent opens a PR,
+ * so the footer updates without waiting for the next poll tick.
+ */
+export function isPrCreateCommand(command: string): boolean {
+  return /(^|[\s;&|(])gh\s+pr\s+create(\s|$)/.test(command);
+}

--- a/packages/pi-pr/src/gh.test.ts
+++ b/packages/pi-pr/src/gh.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchPullRequest, type GhExec, parsePullRequest } from "./gh.js";
+
+function fakeExec(result: { stdout?: string; code?: number } | Error): GhExec {
+  return {
+    exec: vi.fn(async () => {
+      if (result instanceof Error) {
+        throw result;
+      }
+      return {
+        stdout: result.stdout ?? "",
+        stderr: "",
+        code: result.code ?? 0,
+        killed: false,
+      };
+    }),
+  };
+}
+
+const openPr = JSON.stringify({
+  number: 7,
+  url: "https://example.com/pr/7",
+  state: "OPEN",
+  isDraft: false,
+  mergeable: "MERGEABLE",
+  reviewDecision: "APPROVED",
+  statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }],
+});
+
+describe("parsePullRequest", () => {
+  it("maps a fully open, green, approved PR", () => {
+    expect(parsePullRequest(openPr)).toEqual({
+      number: 7,
+      url: "https://example.com/pr/7",
+      lifecycle: "open",
+      ci: "success",
+      merge: "clean",
+      review: "approved",
+    });
+  });
+
+  it("derives lifecycle from state and isDraft", () => {
+    const draft = { number: 1, url: "u", state: "OPEN", isDraft: true };
+    const merged = { number: 1, url: "u", state: "MERGED" };
+    const closed = { number: 1, url: "u", state: "CLOSED" };
+    expect(parsePullRequest(JSON.stringify(draft))?.lifecycle).toBe("draft");
+    expect(parsePullRequest(JSON.stringify(merged))?.lifecycle).toBe("merged");
+    expect(parsePullRequest(JSON.stringify(closed))?.lifecycle).toBe("closed");
+  });
+
+  it("aggregates CI: failure beats running beats success", () => {
+    const rollup = (checks: unknown[]) =>
+      parsePullRequest(JSON.stringify({ number: 1, url: "u", statusCheckRollup: checks }))?.ci;
+
+    expect(rollup([{ conclusion: "SUCCESS" }, { conclusion: "FAILURE" }])).toBe("failure");
+    expect(rollup([{ conclusion: "SUCCESS" }, { status: "IN_PROGRESS" }])).toBe("running");
+    expect(rollup([{ conclusion: "SUCCESS" }, { conclusion: "SUCCESS" }])).toBe("success");
+    expect(rollup([])).toBe("none");
+  });
+
+  it("treats statusContext state field for CI", () => {
+    const rollup = (checks: unknown[]) =>
+      parsePullRequest(JSON.stringify({ number: 1, url: "u", statusCheckRollup: checks }))?.ci;
+    expect(rollup([{ state: "FAILURE" }])).toBe("failure");
+    expect(rollup([{ state: "PENDING" }])).toBe("running");
+    expect(rollup([{ state: "SUCCESS" }])).toBe("success");
+  });
+
+  it("maps merge states", () => {
+    const merge = (mergeable: string) =>
+      parsePullRequest(JSON.stringify({ number: 1, url: "u", mergeable }))?.merge;
+    expect(merge("CONFLICTING")).toBe("conflict");
+    expect(merge("MERGEABLE")).toBe("clean");
+    expect(merge("UNKNOWN")).toBe("unknown");
+  });
+
+  it("maps review decisions, defaulting empty/null to none", () => {
+    const review = (reviewDecision: unknown) =>
+      parsePullRequest(JSON.stringify({ number: 1, url: "u", reviewDecision }))?.review;
+    expect(review("CHANGES_REQUESTED")).toBe("changes_requested");
+    expect(review("REVIEW_REQUIRED")).toBe("review_required");
+    expect(review(null)).toBe("none");
+    expect(review("")).toBe("none");
+  });
+
+  it("returns null for malformed json or missing identity fields", () => {
+    expect(parsePullRequest("not json")).toBeNull();
+    expect(parsePullRequest("{}")).toBeNull();
+    expect(parsePullRequest(JSON.stringify({ number: 1 }))).toBeNull();
+    expect(parsePullRequest(JSON.stringify({ url: "u" }))).toBeNull();
+  });
+});
+
+describe("fetchPullRequest", () => {
+  const signal = new AbortController().signal;
+
+  it("parses gh stdout on success", async () => {
+    const pi = fakeExec({ stdout: openPr, code: 0 });
+    const pr = await fetchPullRequest(pi, signal);
+    expect(pr?.number).toBe(7);
+    expect(pi.exec).toHaveBeenCalledWith(
+      "gh",
+      ["pr", "view", "--json", expect.any(String)],
+      expect.objectContaining({ signal }),
+    );
+  });
+
+  it("returns null on non-zero exit (no PR / not a repo)", async () => {
+    expect(await fetchPullRequest(fakeExec({ code: 1 }), signal)).toBeNull();
+  });
+
+  it("returns null when gh is missing (exec throws)", async () => {
+    expect(await fetchPullRequest(fakeExec(new Error("ENOENT")), signal)).toBeNull();
+  });
+
+  it("returns null on malformed stdout", async () => {
+    expect(await fetchPullRequest(fakeExec({ stdout: "garbage", code: 0 }), signal)).toBeNull();
+  });
+});

--- a/packages/pi-pr/src/gh.ts
+++ b/packages/pi-pr/src/gh.ts
@@ -1,0 +1,153 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export interface PullRequest {
+  number: number;
+  url: string;
+  lifecycle: "open" | "draft" | "merged" | "closed";
+  ci: "success" | "failure" | "running" | "none";
+  merge: "clean" | "conflict" | "unknown";
+  review: "approved" | "changes_requested" | "review_required" | "none";
+}
+
+/** Minimal surface of `ExtensionAPI` needed to run gh — lets tests inject a fake. */
+export type GhExec = Pick<ExtensionAPI, "exec">;
+
+const GH_FIELDS =
+  "number,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup";
+
+const FAILURE_CONCLUSIONS = new Set([
+  "FAILURE",
+  "TIMED_OUT",
+  "CANCELLED",
+  "ACTION_REQUIRED",
+  "STARTUP_FAILURE",
+  "ERROR",
+]);
+
+const RUNNING_STATUSES = new Set(["QUEUED", "IN_PROGRESS", "PENDING", "WAITING"]);
+
+/**
+ * Resolve the current branch's GitHub PR via `gh pr view` and map it to a
+ * {@link PullRequest}.
+ *
+ * Returns `null` for every non-success path — no PR for the branch, not a git
+ * repo, gh missing/unauthenticated, non-zero exit, or malformed output. The
+ * caller treats `null` as "nothing to show" and stays silent.
+ */
+export async function fetchPullRequest(
+  pi: GhExec,
+  signal: AbortSignal,
+): Promise<PullRequest | null> {
+  let stdout: string;
+  try {
+    const result = await pi.exec("gh", ["pr", "view", "--json", GH_FIELDS], {
+      signal,
+      timeout: 10_000,
+    });
+    if (result.code !== 0) {
+      return null;
+    }
+    stdout = result.stdout;
+  } catch {
+    return null;
+  }
+
+  return parsePullRequest(stdout);
+}
+
+interface GhCheck {
+  status?: string;
+  conclusion?: string;
+  state?: string;
+}
+
+interface GhPullRequest {
+  number?: number;
+  url?: string;
+  state?: string;
+  isDraft?: boolean;
+  mergeable?: string;
+  reviewDecision?: string | null;
+  statusCheckRollup?: GhCheck[];
+}
+
+export function parsePullRequest(json: string): PullRequest | null {
+  let raw: GhPullRequest;
+  try {
+    raw = JSON.parse(json) as GhPullRequest;
+  } catch {
+    return null;
+  }
+
+  if (typeof raw.number !== "number" || typeof raw.url !== "string") {
+    return null;
+  }
+
+  return {
+    number: raw.number,
+    url: raw.url,
+    lifecycle: parseLifecycle(raw),
+    ci: parseCi(raw.statusCheckRollup),
+    merge: parseMerge(raw.mergeable),
+    review: parseReview(raw.reviewDecision),
+  };
+}
+
+function parseLifecycle(raw: GhPullRequest): PullRequest["lifecycle"] {
+  if (raw.state === "MERGED") {
+    return "merged";
+  }
+  if (raw.state === "CLOSED") {
+    return "closed";
+  }
+  if (raw.isDraft) {
+    return "draft";
+  }
+  return "open";
+}
+
+function parseCi(checks: GhCheck[] | undefined): PullRequest["ci"] {
+  if (!Array.isArray(checks) || checks.length === 0) {
+    return "none";
+  }
+
+  const hasFailure = checks.some(
+    (check) =>
+      FAILURE_CONCLUSIONS.has(check.conclusion ?? "") || FAILURE_CONCLUSIONS.has(check.state ?? ""),
+  );
+  if (hasFailure) {
+    return "failure";
+  }
+
+  const hasRunning = checks.some(
+    (check) => RUNNING_STATUSES.has(check.status ?? "") || RUNNING_STATUSES.has(check.state ?? ""),
+  );
+  if (hasRunning) {
+    return "running";
+  }
+
+  return "success";
+}
+
+function parseMerge(mergeable: string | undefined): PullRequest["merge"] {
+  if (mergeable === "CONFLICTING") {
+    return "conflict";
+  }
+  if (mergeable === "MERGEABLE") {
+    return "clean";
+  }
+  return "unknown";
+}
+
+function parseReview(decision: string | null | undefined): PullRequest["review"] {
+  switch (decision) {
+    case "APPROVED":
+      return "approved";
+    case "CHANGES_REQUESTED":
+      return "changes_requested";
+    case "REVIEW_REQUIRED":
+      return "review_required";
+    default:
+      return "none";
+  }
+}

--- a/packages/pi-pr/src/index.ts
+++ b/packages/pi-pr/src/index.ts
@@ -1,8 +1,10 @@
-import type {
-  ExtensionAPI,
-  ExtensionCommandContext,
-  ExtensionContext,
+import {
+  type ExtensionAPI,
+  type ExtensionCommandContext,
+  type ExtensionContext,
+  isBashToolResult,
 } from "@earendil-works/pi-coding-agent";
+import { isPrCreateCommand } from "./command.js";
 import { fetchPullRequest } from "./gh.js";
 import { renderStatus } from "./status.js";
 
@@ -55,6 +57,13 @@ export default function piPr(pi: ExtensionAPI): void {
   });
 
   pi.on("session_shutdown", () => stop());
+
+  // Refresh right after the agent opens a PR so the footer updates immediately.
+  pi.on("tool_result", (event, ctx) => {
+    if (isBashToolResult(event) && isPrCreateCommand(String(event.input.command ?? ""))) {
+      void pollOnce(ctx);
+    }
+  });
 
   pi.registerCommand("pr", {
     description: "Open the current branch's PR in the browser and refresh its status",

--- a/packages/pi-pr/src/index.ts
+++ b/packages/pi-pr/src/index.ts
@@ -1,0 +1,72 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { fetchPullRequest } from "./gh.js";
+import { renderStatus } from "./status.js";
+
+const STATUS_KEY = "pi-pr";
+const DEFAULT_INTERVAL_SECONDS = 30;
+const MIN_INTERVAL_SECONDS = 5;
+
+export default function piPr(pi: ExtensionAPI): void {
+  // Flags are boolean|string only; interval is a numeric string parsed at use.
+  pi.registerFlag("pi-pr-interval", {
+    type: "string",
+    description: `Poll interval in seconds (minimum ${MIN_INTERVAL_SECONDS}).`,
+    default: String(DEFAULT_INTERVAL_SECONDS),
+  });
+
+  let timer: NodeJS.Timeout | null = null;
+  let controller: AbortController | null = null;
+  let polling = false;
+
+  const stop = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+    controller?.abort();
+    controller = null;
+    polling = false;
+  };
+
+  const pollOnce = async (ctx: ExtensionContext) => {
+    if (polling) {
+      return;
+    }
+    polling = true;
+    controller = new AbortController();
+    try {
+      const pr = await fetchPullRequest(pi, controller.signal);
+      ctx.ui.setStatus(STATUS_KEY, pr ? renderStatus(pr, ctx.ui.theme) : undefined);
+    } finally {
+      controller = null;
+      polling = false;
+    }
+  };
+
+  pi.on("session_start", (_event, ctx) => {
+    stop();
+    void pollOnce(ctx);
+    const ms = intervalMs(pi);
+    timer = setInterval(() => void pollOnce(ctx), ms);
+  });
+
+  pi.on("session_shutdown", () => stop());
+
+  pi.registerCommand("pr", {
+    description: "Open the current branch's PR in the browser and refresh its status",
+    handler: async (_args: string, ctx: ExtensionCommandContext) => {
+      await pi.exec("gh", ["pr", "view", "--web"], { timeout: 5_000 }).catch(() => {});
+      await pollOnce(ctx);
+    },
+  });
+}
+
+function intervalMs(pi: ExtensionAPI): number {
+  const raw = Number(pi.getFlag("pi-pr-interval"));
+  const seconds = Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_INTERVAL_SECONDS;
+  return Math.max(MIN_INTERVAL_SECONDS, seconds) * 1000;
+}

--- a/packages/pi-pr/src/osc8.test.ts
+++ b/packages/pi-pr/src/osc8.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { hyperlink } from "./osc8.js";
+
+describe("hyperlink", () => {
+  it("wraps text in an OSC 8 open/close pair", () => {
+    expect(hyperlink("https://example.com/pr/1", "#1")).toBe(
+      "\x1b]8;;https://example.com/pr/1\x1b\\#1\x1b]8;;\x1b\\",
+    );
+  });
+
+  it("emits an empty URL and empty text faithfully", () => {
+    expect(hyperlink("", "")).toBe("\x1b]8;;\x1b\\\x1b]8;;\x1b\\");
+  });
+});

--- a/packages/pi-pr/src/osc8.ts
+++ b/packages/pi-pr/src/osc8.ts
@@ -1,0 +1,11 @@
+const ST = "\x1b\\";
+
+/**
+ * Wrap `text` in an OSC 8 terminal hyperlink pointing at `url`.
+ *
+ * Produces `ESC ]8;;URL ST TEXT ESC ]8;; ST`, the standard open/close pair.
+ * Kept terminal-agnostic and side-effect free so it is unit-testable.
+ */
+export function hyperlink(url: string, text: string): string {
+  return `\x1b]8;;${url}${ST}${text}\x1b]8;;${ST}`;
+}

--- a/packages/pi-pr/src/status.test.ts
+++ b/packages/pi-pr/src/status.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { PullRequest } from "./gh.js";
+import { renderStatus, type ThemeLike } from "./status.js";
+
+// Fake theme: fg(token, text) => `[token]text`, so assertions can read both the
+// color token and the glyph it wraps.
+const theme: ThemeLike = {
+  fg: (color, text) => `[${color}]${text}`,
+};
+
+const base: PullRequest = {
+  number: 42,
+  url: "https://example.com/pr/42",
+  lifecycle: "open",
+  ci: "success",
+  merge: "clean",
+  review: "approved",
+};
+
+function pr(overrides: Partial<PullRequest>): PullRequest {
+  return { ...base, ...overrides };
+}
+
+describe("renderStatus", () => {
+  it("renders CI before the review verdict", () => {
+    const out = renderStatus(base, theme);
+    const ci = out.indexOf("●");
+    const review = out.indexOf("✓");
+    expect(ci).toBeGreaterThan(-1);
+    expect(ci).toBeLessThan(review);
+  });
+
+  it("colors CI and the approved verdict; omits conflict glyph when not conflicting", () => {
+    const out = renderStatus(base, theme);
+    expect(out).toContain("[success]●");
+    expect(out).toContain("[success]✓");
+    expect(out).not.toContain("‼");
+  });
+
+  it("maps CI states to color tokens", () => {
+    expect(renderStatus(pr({ ci: "failure" }), theme)).toContain("[error]●");
+    expect(renderStatus(pr({ ci: "running" }), theme)).toContain("[warning]●");
+    expect(renderStatus(pr({ ci: "none" }), theme)).toContain("[dim]●");
+  });
+
+  it("shows the red conflict glyph only on conflict, between CI and review", () => {
+    const conflicting = renderStatus(pr({ merge: "conflict" }), theme);
+    expect(conflicting).toContain("[error]‼");
+    expect(conflicting.indexOf("●")).toBeLessThan(conflicting.indexOf("‼"));
+    expect(conflicting.indexOf("‼")).toBeLessThan(conflicting.indexOf("✓"));
+
+    expect(renderStatus(pr({ merge: "clean" }), theme)).not.toContain("‼");
+    expect(renderStatus(pr({ merge: "unknown" }), theme)).not.toContain("‼");
+  });
+
+  it("shows the review verdict only for approved / changes_requested", () => {
+    expect(renderStatus(pr({ review: "approved" }), theme)).toContain("[success]✓");
+
+    const changes = renderStatus(pr({ review: "changes_requested" }), theme);
+    expect(changes).toContain("[error]✗");
+    expect(changes).not.toContain("✓");
+
+    for (const review of ["review_required", "none"] as const) {
+      const out = renderStatus(pr({ review }), theme);
+      expect(out).not.toContain("✓");
+      expect(out).not.toContain("✗");
+    }
+  });
+
+  it("orders conflict before the review verdict", () => {
+    const out = renderStatus(pr({ merge: "conflict", review: "changes_requested" }), theme);
+    expect(out.indexOf("●")).toBeLessThan(out.indexOf("‼"));
+    expect(out.indexOf("‼")).toBeLessThan(out.indexOf("✗"));
+  });
+
+  it("colors #n by lifecycle", () => {
+    expect(renderStatus(pr({ lifecycle: "draft" }), theme)).toContain("[dim]#42");
+    expect(renderStatus(pr({ lifecycle: "open" }), theme)).toContain("[text]#42");
+    expect(renderStatus(pr({ lifecycle: "merged" }), theme)).toContain("[muted]#42");
+    expect(renderStatus(pr({ lifecycle: "closed" }), theme)).toContain("[error]#42");
+  });
+
+  it("wraps #n in an OSC 8 link to the PR url", () => {
+    const out = renderStatus(base, theme);
+    expect(out).toContain(`\x1b]8;;${base.url}\x1b\\`);
+    expect(out).toContain("[text]#42");
+    expect(out).toContain("\x1b]8;;\x1b\\");
+  });
+});

--- a/packages/pi-pr/src/status.ts
+++ b/packages/pi-pr/src/status.ts
@@ -1,0 +1,68 @@
+import type { ThemeColor } from "@earendil-works/pi-coding-agent";
+import type { PullRequest } from "./gh.js";
+import { hyperlink } from "./osc8.js";
+
+/** Minimal theme surface used for rendering — lets tests inject a fake. */
+export interface ThemeLike {
+  fg(color: ThemeColor, text: string): string;
+}
+
+const CI_GLYPH = "●";
+const CONFLICT_GLYPH = "‼";
+const APPROVED_GLYPH = "✓";
+const CHANGES_GLYPH = "✗";
+
+const CI_COLOR: Record<PullRequest["ci"], ThemeColor> = {
+  success: "success",
+  failure: "error",
+  running: "warning",
+  none: "dim",
+};
+
+// Theme tokens have no "purple"; merged falls back to "muted" to stay distinct
+// from open (accent), closed (error) and draft (dim). See README.
+const LIFECYCLE_COLOR: Record<PullRequest["lifecycle"], ThemeColor> = {
+  draft: "dim",
+  open: "text",
+  merged: "muted",
+  closed: "error",
+};
+
+/**
+ * Render a footer string for a {@link PullRequest}: a clickable `#n` link
+ * (colored by lifecycle) followed by the CI glyph `●` (always shown, `none`
+ * dim so its position stays stable), then two conditional glyphs that appear
+ * only in specific states — a red conflict `‼` when the PR can't merge, and a
+ * review verdict (`✓` green approved, `✗` red changes-requested; nothing for
+ * `review_required`/`none`).
+ */
+export function renderStatus(pr: PullRequest, theme: ThemeLike): string {
+  const link = renderLink(pr, theme);
+  const dots = [renderCI(pr, theme), renderConflict(pr, theme), renderReview(pr, theme)].join("");
+
+  return [link, dots].join(" ");
+}
+
+function renderLink(pr: PullRequest, theme: ThemeLike) {
+  const label = theme.fg(LIFECYCLE_COLOR[pr.lifecycle], `#${pr.number}`);
+  return hyperlink(pr.url, label);
+}
+
+function renderCI(pr: PullRequest, theme: ThemeLike): string {
+  return theme.fg(CI_COLOR[pr.ci], CI_GLYPH);
+}
+
+function renderConflict(pr: PullRequest, theme: ThemeLike): string {
+  return pr.merge === "conflict" ? theme.fg("error", CONFLICT_GLYPH) : "";
+}
+
+function renderReview(pr: PullRequest, theme: ThemeLike): string {
+  switch (pr.review) {
+    case "approved":
+      return theme.fg("success", APPROVED_GLYPH);
+    case "changes_requested":
+      return theme.fg("error", CHANGES_GLYPH);
+    default:
+      return "";
+  }
+}

--- a/packages/pi-pr/tsconfig.json
+++ b/packages/pi-pr/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,24 @@ importers:
         specifier: ^3.2.1
         version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
 
+  packages/pi-pr:
+    devDependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
+
   packages/pi-reflag:
     dependencies:
       web-tree-sitter:


### PR DESCRIPTION
## Motivation

Before, checking a branch's PR meant leaving the terminal — run `gh pr view` or open the browser to see if CI passed, if there's a merge conflict, or if a review came back. This adds a new `pi-pr` extension that keeps that state in view. The footer shows the current branch's PR live, so you catch a failed check or a conflict early without breaking flow.

## Changes

- **New `pi-pr` extension.** Shows the current branch's PR in the pi footer: a lifecycle letter (`D` draft, `O` open, `M` merged — purple) and a clickable `#n` link (both colored by lifecycle), a CI status dot `●`, a red `‼` on merge conflicts, and a review verdict (`✓` approved, `✗` changes requested). Closed PRs show nothing.
- **Background polling.** Refreshes every 30s by default; set with the `pi-pr-interval` flag (seconds, floored at 5). Stays silent when there's no PR, no git repo, or `gh` is missing/unauthenticated.
- **Instant refresh on PR open.** When the agent runs `gh pr create`, the footer updates right away instead of waiting for the next poll.
- **`/pr` command.** Opens the branch's PR in the browser and refreshes the footer.
- **Docs.** Added the package to the README table and AGENTS.md.

## QA

Added unit tests (`gh`, `status`, `osc8`, `command`). To check by hand: install it, check out a branch with an open PR, and confirm the footer shows the letter + `#n` and a status dot. Click `#n` to open the PR; run `/pr` to open the browser and refresh. Run `gh pr create` — `#n` appears without waiting for the next poll. On a branch with no PR (or a closed one), the footer stays empty.

## Blast Radius

New package only — `packages/pi-pr`. Touches no other extension. Uses the existing `gh` CLI at runtime; no new runtime deps. README and AGENTS.md doc edits. No datastore migration.
