### PR TITLE
feat(pi-bash-timeout): add bash timeout policy extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Flags:
 ### `pi-bash-timeout` (`packages/pi-bash-timeout`)
 Intercepts `bash` tool calls via `tool_call` and injects a default `timeout` (seconds) when the model omits it or passes `<= 0`, mutating `event.input` in place (uses the upstream `isToolCallEventType("bash", event)` guard). Appends a "Bash Tool Timeout Policy" section to the system prompt via `before_agent_start` so the model sets explicit timeouts for long-running commands.
 
-Timeout values resolve with precedence **flag > env var > built-in**; invalid or non-positive values fall through to the next source. `maxSeconds` is advisory only (shown in prompt guidance) and is never a hard cap — explicit timeouts always pass through; it is raised to the default when lower. Flags register **without** a `default` on purpose: `getFlag` returns the registered default immediately once set, so a default would permanently shadow the env var — leaving it unset lets `getFlag` return `undefined` and the env layer take over.
+Timeout values resolve with precedence **flag > env var > built-in**; invalid or non-positive values fall through to the next source. Explicit timeouts above `maxSeconds` are capped; max is raised to the default when lower. Flags register **without** a `default` on purpose: `getFlag` returns the registered default immediately once set, so a default would permanently shadow the env var — leaving it unset lets `getFlag` return `undefined` and the env layer take over.
 
 Ported and adapted from [`code-yeongyu/pi-bash-timeout`](https://github.com/code-yeongyu/pi-bash-timeout).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,17 @@ Shows the current branch's GitHub PR in the footer via `ctx.ui.setStatus("pi-pr"
 Flags:
 - `pi-pr-interval` (string numeric, default: `30`) — poll interval in seconds, floored at 5s (registered as a string flag because pi flags are boolean or string only; parsed as a number at use)
 
+### `pi-bash-timeout` (`packages/pi-bash-timeout`)
+Intercepts `bash` tool calls via `tool_call` and injects a default `timeout` (seconds) when the model omits it or passes `<= 0`, mutating `event.input` in place (uses the upstream `isToolCallEventType("bash", event)` guard). Appends a "Bash Tool Timeout Policy" section to the system prompt via `before_agent_start` so the model sets explicit timeouts for long-running commands.
+
+Timeout values resolve with precedence **flag > env var > built-in**; invalid or non-positive values fall through to the next source. `maxSeconds` is advisory only (shown in prompt guidance) and is never a hard cap — explicit timeouts always pass through; it is raised to the default when lower. Flags register **without** a `default` on purpose: `getFlag` returns the registered default immediately once set, so a default would permanently shadow the env var — leaving it unset lets `getFlag` return `undefined` and the env layer take over.
+
+Ported and adapted from [`code-yeongyu/pi-bash-timeout`](https://github.com/code-yeongyu/pi-bash-timeout).
+
+Flags:
+- `pi-bash-timeout-default` (string numeric, no default; falls back to `PI_BASH_DEFAULT_TIMEOUT_SECONDS` env, then built-in `120`)
+- `pi-bash-timeout-max` (string numeric, no default; falls back to `PI_BASH_MAX_TIMEOUT_SECONDS` env, then built-in `600`)
+
 ## Tech stack
 
 - **Runtime**: Node.js ≥ 22.19.0, ESM throughout (`"type": "module"`)

--- a/packages/pi-bash-timeout/README.md
+++ b/packages/pi-bash-timeout/README.md
@@ -4,7 +4,7 @@ Pi Agent extension that gives the `bash` tool a sane default timeout and tells t
 
 It intercepts the host `bash` tool via the `tool_call` event and injects a default `timeout` (in seconds) when the model omits it or passes a non-positive value. It also appends a "Bash Tool Timeout Policy" section to the system prompt via `before_agent_start` so the model sets explicit timeouts for long-running commands.
 
-Ported from [`code-yeongyu/pi-bash-timeout`](https://github.com/code-yeongyu/pi-bash-timeout) and adapted to this repo (pi flags, upstream `isToolCallEventType` guard, in-place input mutation, colocated tests).
+
 
 ## Behavior
 
@@ -28,7 +28,9 @@ Both pi flags and env vars are supported. Precedence: **flag > env var > built-i
 
 Explicit `timeout` values above max are capped. If `max` resolves lower than `default`, it is raised to `default`.
 
-Env var names match `senpi-mono` for compatibility.
+## Thanks
+
+Ported from [`code-yeongyu/pi-bash-timeout`](https://github.com/code-yeongyu/pi-bash-timeout) and adapted to this repo (pi flags, upstream `isToolCallEventType` guard, in-place input mutation, colocated tests).
 
 ## Development
 

--- a/packages/pi-bash-timeout/README.md
+++ b/packages/pi-bash-timeout/README.md
@@ -1,0 +1,35 @@
+# @piotr-oles/pi-bash-timeout
+
+Pi Agent extension that gives the `bash` tool a sane default timeout and tells the model about the timeout policy.
+
+It intercepts the host `bash` tool via the `tool_call` event and injects a default `timeout` (in seconds) when the model omits it or passes a non-positive value. It also appends a "Bash Tool Timeout Policy" section to the system prompt via `before_agent_start` so the model sets explicit timeouts for long-running commands.
+
+Ported from [`code-yeongyu/pi-bash-timeout`](https://github.com/code-yeongyu/pi-bash-timeout) and adapted to this repo (pi flags, upstream `isToolCallEventType` guard, in-place input mutation, colocated tests).
+
+## Behavior
+
+| Case | Result |
+|------|--------|
+| `timeout` omitted | inject default |
+| `timeout <= 0` | treated as missing, inject default |
+| `timeout` in range | preserved |
+| `timeout` above max | preserved (max is advisory, not a hard cap) |
+
+Non-`bash` tool calls are never touched.
+
+## Configuration
+
+Both pi flags and env vars are supported. Precedence: **flag > env var > built-in default**. Invalid or non-positive values are ignored and fall through to the next source.
+
+| Setting | Flag | Env var | Default |
+|---------|------|---------|---------|
+| Default timeout (s) | `pi-bash-timeout-default` | `PI_BASH_DEFAULT_TIMEOUT_SECONDS` | `120` |
+| Advisory max (s) | `pi-bash-timeout-max` | `PI_BASH_MAX_TIMEOUT_SECONDS` | `600` |
+
+The max value only appears in prompt guidance; explicit `timeout` values are never capped. If `max` resolves lower than `default`, it is raised to `default`.
+
+Env var names match `senpi-mono` for compatibility.
+
+## License
+
+MIT

--- a/packages/pi-bash-timeout/README.md
+++ b/packages/pi-bash-timeout/README.md
@@ -13,7 +13,7 @@ Ported from [`code-yeongyu/pi-bash-timeout`](https://github.com/code-yeongyu/pi-
 | `timeout` omitted | inject default |
 | `timeout <= 0` | treated as missing, inject default |
 | `timeout` in range | preserved |
-| `timeout` above max | preserved (max is advisory, not a hard cap) |
+| `timeout` above max | capped to max |
 
 Non-`bash` tool calls are never touched.
 
@@ -24,12 +24,23 @@ Both pi flags and env vars are supported. Precedence: **flag > env var > built-i
 | Setting | Flag | Env var | Default |
 |---------|------|---------|---------|
 | Default timeout (s) | `pi-bash-timeout-default` | `PI_BASH_DEFAULT_TIMEOUT_SECONDS` | `120` |
-| Advisory max (s) | `pi-bash-timeout-max` | `PI_BASH_MAX_TIMEOUT_SECONDS` | `600` |
+| Maximum timeout (s) | `pi-bash-timeout-max` | `PI_BASH_MAX_TIMEOUT_SECONDS` | `600` |
 
-The max value only appears in prompt guidance; explicit `timeout` values are never capped. If `max` resolves lower than `default`, it is raised to `default`.
+Explicit `timeout` values above max are capped. If `max` resolves lower than `default`, it is raised to `default`.
 
 Env var names match `senpi-mono` for compatibility.
 
-## License
+## Development
 
-MIT
+```bash
+pnpm install
+pnpm test
+pnpm typecheck
+pnpm check
+```
+
+To test changes manually, pass the source entry point directly to pi:
+
+```bash
+pi -e packages/pi-bash-timeout/src/index.ts
+```

--- a/packages/pi-bash-timeout/package.json
+++ b/packages/pi-bash-timeout/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@piotr-oles/pi-bash-timeout",
+  "version": "0.0.0",
+  "description": "Pi Agent extension: inject a default bash timeout and append timeout policy guidance to the system prompt",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piotr-oles/pi-extensions.git",
+    "directory": "packages/pi-bash-timeout"
+  },
+  "keywords": [
+    "pi-package"
+  ],
+  "type": "module",
+  "files": [
+    "src",
+    "!src/*.test.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "biome ci src/",
+    "fix": "biome check --write src/",
+    "release": "semantic-release -e semantic-release-monorepo"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-agent-core": "^0.75.5",
+    "@earendil-works/pi-coding-agent": "^0.75.5",
+    "@marcfargas/pi-test-harness": "^0.6.1",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.1"
+  }
+}

--- a/packages/pi-bash-timeout/src/index.test.ts
+++ b/packages/pi-bash-timeout/src/index.test.ts
@@ -1,0 +1,130 @@
+import {
+  calls,
+  createTestSession,
+  says,
+  type TestSession,
+  when,
+} from "@marcfargas/pi-test-harness";
+import { afterEach, describe, expect, it } from "vitest";
+import piBashTimeout from "./index.js";
+
+function withFlags(flags: Record<string, string>) {
+  return (pi: any) => {
+    const orig = pi.getFlag.bind(pi);
+    pi.getFlag = (name: string) => (name in flags ? flags[name] : orig(name));
+    piBashTimeout(pi);
+  };
+}
+
+describe("pi-bash-timeout", { timeout: 30_000 }, () => {
+  let t: TestSession;
+  afterEach(() => t?.dispose());
+
+  // The harness records the pre-mutation input, so assert on the params the
+  // tool actually executed with (captured by the mock handler) instead.
+  function captureExec() {
+    const executed: Record<string, unknown>[] = [];
+    const handler = (params: Record<string, unknown>) => {
+      executed.push(params);
+      return "ok";
+    };
+    return { executed, handler };
+  }
+
+  it("injects the default timeout when the model omits it", async () => {
+    const bash = captureExec();
+    t = await createTestSession({
+      extensionFactories: [(pi: any) => piBashTimeout(pi)],
+      mockTools: { bash: bash.handler },
+    });
+
+    await t.run(when("run", [calls("bash", { command: "echo hi" }), says("done")]));
+
+    expect(bash.executed[0]?.timeout).toBe(120);
+  });
+
+  it("preserves an explicit in-range timeout", async () => {
+    const bash = captureExec();
+    t = await createTestSession({
+      extensionFactories: [(pi: any) => piBashTimeout(pi)],
+      mockTools: { bash: bash.handler },
+    });
+
+    await t.run(when("run", [calls("bash", { command: "sleep 5", timeout: 30 }), says("done")]));
+
+    expect(bash.executed[0]?.timeout).toBe(30);
+  });
+
+  it("preserves an explicit timeout above the advisory max (no hard cap)", async () => {
+    const bash = captureExec();
+    t = await createTestSession({
+      extensionFactories: [(pi: any) => piBashTimeout(pi)],
+      mockTools: { bash: bash.handler },
+    });
+
+    await t.run(
+      when("run", [calls("bash", { command: "sleep 9999", timeout: 9999 }), says("done")]),
+    );
+
+    expect(bash.executed[0]?.timeout).toBe(9999);
+  });
+
+  it("treats a non-positive timeout as missing and injects the default", async () => {
+    const bash = captureExec();
+    t = await createTestSession({
+      extensionFactories: [(pi: any) => piBashTimeout(pi)],
+      mockTools: { bash: bash.handler },
+    });
+
+    await t.run(when("run", [calls("bash", { command: "echo hi", timeout: 0 }), says("done")]));
+
+    expect(bash.executed[0]?.timeout).toBe(120);
+  });
+
+  it("uses the flag value over the built-in default", async () => {
+    const bash = captureExec();
+    t = await createTestSession({
+      extensionFactories: [withFlags({ "pi-bash-timeout-default": "45" })],
+      mockTools: { bash: bash.handler },
+    });
+
+    await t.run(when("run", [calls("bash", { command: "echo hi" }), says("done")]));
+
+    expect(bash.executed[0]?.timeout).toBe(45);
+  });
+
+  it("does not touch non-bash tool calls", async () => {
+    const read = captureExec();
+    t = await createTestSession({
+      extensionFactories: [(pi: any) => piBashTimeout(pi)],
+      mockTools: { read: read.handler },
+    });
+
+    await t.run(when("run", [calls("read", { path: "foo.txt" }), says("done")]));
+
+    expect(read.executed[0]?.timeout).toBeUndefined();
+  });
+});
+
+describe("pi-bash-timeout before_agent_start", () => {
+  it("appends the timeout policy section to the system prompt", () => {
+    let handler: ((event: { systemPrompt: string }) => { systemPrompt: string }) | undefined;
+    const pi = {
+      registerFlag() {},
+      getFlag: () => undefined,
+      on(event: string, fn: unknown) {
+        if (event === "before_agent_start") {
+          handler = fn as typeof handler;
+        }
+      },
+    };
+
+    piBashTimeout(pi as never);
+    expect(handler).toBeTypeOf("function");
+
+    const result = handler?.({ systemPrompt: "base prompt" });
+    expect(result?.systemPrompt).toContain("base prompt");
+    expect(result?.systemPrompt).toContain("Bash Tool Timeout Policy");
+    expect(result?.systemPrompt).toContain("Default timeout: 120s (2 min)");
+  });
+});

--- a/packages/pi-bash-timeout/src/index.test.ts
+++ b/packages/pi-bash-timeout/src/index.test.ts
@@ -55,7 +55,7 @@ describe("pi-bash-timeout", { timeout: 30_000 }, () => {
     expect(bash.executed[0]?.timeout).toBe(30);
   });
 
-  it("preserves an explicit timeout above the advisory max (no hard cap)", async () => {
+  it("caps an explicit timeout above the maximum", async () => {
     const bash = captureExec();
     t = await createTestSession({
       extensionFactories: [(pi: any) => piBashTimeout(pi)],
@@ -66,7 +66,7 @@ describe("pi-bash-timeout", { timeout: 30_000 }, () => {
       when("run", [calls("bash", { command: "sleep 9999", timeout: 9999 }), says("done")]),
     );
 
-    expect(bash.executed[0]?.timeout).toBe(9999);
+    expect(bash.executed[0]?.timeout).toBe(600);
   });
 
   it("treats a non-positive timeout as missing and injects the default", async () => {
@@ -125,6 +125,7 @@ describe("pi-bash-timeout before_agent_start", () => {
     const result = handler?.({ systemPrompt: "base prompt" });
     expect(result?.systemPrompt).toContain("base prompt");
     expect(result?.systemPrompt).toContain("Bash Tool Timeout Policy");
-    expect(result?.systemPrompt).toContain("Default timeout: 120s (2 min)");
+    expect(result?.systemPrompt).toContain("Default timeout: 120s");
+    expect(result?.systemPrompt).toContain("Maximum timeout: 600s");
   });
 });

--- a/packages/pi-bash-timeout/src/index.ts
+++ b/packages/pi-bash-timeout/src/index.ts
@@ -1,36 +1,34 @@
 import { type ExtensionAPI, isToolCallEventType } from "@earendil-works/pi-coding-agent";
-import { buildBashTimeoutPrompt, resolveBashTimeoutDefaults } from "./timeout.js";
+import { buildBashTimeoutPrompt, resolveBashTimeoutConfig } from "./timeout.js";
 
-export type { BashTimeoutDefaults, BashTimeoutFlags } from "./timeout.js";
+export type { BashTimeoutConfig as BashTimeoutDefaults, BashTimeoutFlags } from "./timeout.js";
 export {
   BASH_DEFAULT_TIMEOUT_SECONDS,
   BASH_MAX_TIMEOUT_SECONDS,
   buildBashTimeoutPrompt,
   DEFAULT_TIMEOUT_ENV,
   MAX_TIMEOUT_ENV,
-  resolveBashTimeoutDefaults,
+  resolveBashTimeoutConfig,
 } from "./timeout.js";
 
 const DEFAULT_FLAG = "pi-bash-timeout-default";
 const MAX_FLAG = "pi-bash-timeout-max";
 
 export default function piBashTimeout(pi: ExtensionAPI): void {
-  // No flag `default`: getFlag returns undefined when unset, so the env var
-  // (senpi-mono compat) can take over before the built-in constant.
   pi.registerFlag(DEFAULT_FLAG, {
     type: "string",
     description: "Timeout in seconds injected when the model omits `timeout`. Positive integer.",
   });
   pi.registerFlag(MAX_FLAG, {
     type: "string",
-    description: "Advisory maximum timeout in seconds shown in prompt guidance. Positive integer.",
+    description: "Maximum allowed bash timeout in seconds. Positive integer.",
   });
 
-  const defaults = resolveBashTimeoutDefaults(
+  const config = resolveBashTimeoutConfig(
     { default: pi.getFlag(DEFAULT_FLAG), max: pi.getFlag(MAX_FLAG) },
     process.env,
   );
-  const promptSection = buildBashTimeoutPrompt(defaults);
+  const promptSection = buildBashTimeoutPrompt(config);
 
   pi.on("tool_call", (event) => {
     if (!isToolCallEventType("bash", event)) {
@@ -38,11 +36,13 @@ export default function piBashTimeout(pi: ExtensionAPI): void {
     }
     const timeout = event.input.timeout;
     if (timeout === undefined || timeout <= 0) {
-      event.input.timeout = defaults.defaultSeconds;
+      event.input.timeout = config.defaultSeconds;
+    } else if (timeout > config.maxSeconds) {
+      event.input.timeout = config.maxSeconds;
     }
   });
 
   pi.on("before_agent_start", (event) => ({
-    systemPrompt: `${event.systemPrompt}${promptSection}`,
+    systemPrompt: `${event.systemPrompt}\n\n${promptSection}`,
   }));
 }

--- a/packages/pi-bash-timeout/src/index.ts
+++ b/packages/pi-bash-timeout/src/index.ts
@@ -1,0 +1,48 @@
+import { type ExtensionAPI, isToolCallEventType } from "@earendil-works/pi-coding-agent";
+import { buildBashTimeoutPrompt, resolveBashTimeoutDefaults } from "./timeout.js";
+
+export type { BashTimeoutDefaults, BashTimeoutFlags } from "./timeout.js";
+export {
+  BASH_DEFAULT_TIMEOUT_SECONDS,
+  BASH_MAX_TIMEOUT_SECONDS,
+  buildBashTimeoutPrompt,
+  DEFAULT_TIMEOUT_ENV,
+  MAX_TIMEOUT_ENV,
+  resolveBashTimeoutDefaults,
+} from "./timeout.js";
+
+const DEFAULT_FLAG = "pi-bash-timeout-default";
+const MAX_FLAG = "pi-bash-timeout-max";
+
+export default function piBashTimeout(pi: ExtensionAPI): void {
+  // No flag `default`: getFlag returns undefined when unset, so the env var
+  // (senpi-mono compat) can take over before the built-in constant.
+  pi.registerFlag(DEFAULT_FLAG, {
+    type: "string",
+    description: "Timeout in seconds injected when the model omits `timeout`. Positive integer.",
+  });
+  pi.registerFlag(MAX_FLAG, {
+    type: "string",
+    description: "Advisory maximum timeout in seconds shown in prompt guidance. Positive integer.",
+  });
+
+  const defaults = resolveBashTimeoutDefaults(
+    { default: pi.getFlag(DEFAULT_FLAG), max: pi.getFlag(MAX_FLAG) },
+    process.env,
+  );
+  const promptSection = buildBashTimeoutPrompt(defaults);
+
+  pi.on("tool_call", (event) => {
+    if (!isToolCallEventType("bash", event)) {
+      return;
+    }
+    const timeout = event.input.timeout;
+    if (timeout === undefined || timeout <= 0) {
+      event.input.timeout = defaults.defaultSeconds;
+    }
+  });
+
+  pi.on("before_agent_start", (event) => ({
+    systemPrompt: `${event.systemPrompt}${promptSection}`,
+  }));
+}

--- a/packages/pi-bash-timeout/src/timeout.test.ts
+++ b/packages/pi-bash-timeout/src/timeout.test.ts
@@ -5,12 +5,12 @@ import {
   buildBashTimeoutPrompt,
   DEFAULT_TIMEOUT_ENV,
   MAX_TIMEOUT_ENV,
-  resolveBashTimeoutDefaults,
+  resolveBashTimeoutConfig,
 } from "./timeout.js";
 
 describe("resolveBashTimeoutDefaults", () => {
   it("returns built-in constants when no flag or env is set", () => {
-    const result = resolveBashTimeoutDefaults({}, {});
+    const result = resolveBashTimeoutConfig({}, {});
     expect(result).toEqual({
       defaultSeconds: BASH_DEFAULT_TIMEOUT_SECONDS,
       maxSeconds: BASH_MAX_TIMEOUT_SECONDS,
@@ -18,7 +18,7 @@ describe("resolveBashTimeoutDefaults", () => {
   });
 
   it("uses env vars when no flag is set", () => {
-    const result = resolveBashTimeoutDefaults(
+    const result = resolveBashTimeoutConfig(
       {},
       { [DEFAULT_TIMEOUT_ENV]: "30", [MAX_TIMEOUT_ENV]: "900" },
     );
@@ -26,7 +26,7 @@ describe("resolveBashTimeoutDefaults", () => {
   });
 
   it("prefers flag over env (flag > env precedence)", () => {
-    const result = resolveBashTimeoutDefaults(
+    const result = resolveBashTimeoutConfig(
       { default: "45", max: "300" },
       { [DEFAULT_TIMEOUT_ENV]: "30", [MAX_TIMEOUT_ENV]: "900" },
     );
@@ -34,7 +34,7 @@ describe("resolveBashTimeoutDefaults", () => {
   });
 
   it("falls through to env when a flag value is invalid", () => {
-    const result = resolveBashTimeoutDefaults(
+    const result = resolveBashTimeoutConfig(
       { default: "garbage", max: "0" },
       { [DEFAULT_TIMEOUT_ENV]: "30", [MAX_TIMEOUT_ENV]: "900" },
     );
@@ -42,16 +42,16 @@ describe("resolveBashTimeoutDefaults", () => {
   });
 
   it("ignores invalid env values and falls back to built-in", () => {
-    const garbage = resolveBashTimeoutDefaults({}, { [DEFAULT_TIMEOUT_ENV]: "garbage" });
-    const zero = resolveBashTimeoutDefaults({}, { [DEFAULT_TIMEOUT_ENV]: "0" });
-    const negative = resolveBashTimeoutDefaults({}, { [MAX_TIMEOUT_ENV]: "-1" });
+    const garbage = resolveBashTimeoutConfig({}, { [DEFAULT_TIMEOUT_ENV]: "garbage" });
+    const zero = resolveBashTimeoutConfig({}, { [DEFAULT_TIMEOUT_ENV]: "0" });
+    const negative = resolveBashTimeoutConfig({}, { [MAX_TIMEOUT_ENV]: "-1" });
     expect(garbage.defaultSeconds).toBe(BASH_DEFAULT_TIMEOUT_SECONDS);
     expect(zero.defaultSeconds).toBe(BASH_DEFAULT_TIMEOUT_SECONDS);
     expect(negative.maxSeconds).toBe(BASH_MAX_TIMEOUT_SECONDS);
   });
 
   it("ignores boolean flag values", () => {
-    const result = resolveBashTimeoutDefaults({ default: true, max: false }, {});
+    const result = resolveBashTimeoutConfig({ default: true, max: false }, {});
     expect(result).toEqual({
       defaultSeconds: BASH_DEFAULT_TIMEOUT_SECONDS,
       maxSeconds: BASH_MAX_TIMEOUT_SECONDS,
@@ -59,27 +59,25 @@ describe("resolveBashTimeoutDefaults", () => {
   });
 
   it("raises max up to default when max is lower", () => {
-    const result = resolveBashTimeoutDefaults({ default: "500", max: "100" }, {});
+    const result = resolveBashTimeoutConfig({ default: "500", max: "100" }, {});
     expect(result).toEqual({ defaultSeconds: 500, maxSeconds: 500 });
   });
 });
 
 describe("buildBashTimeoutPrompt", () => {
-  it("labels minute-aligned values in minutes", () => {
+  it("includes configured default and maximum values", () => {
     const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 });
-    expect(prompt).toContain("Default timeout: 120s (2 min)");
-    expect(prompt).toContain("Recommended maximum timeout: 600s (10 min)");
+    expect(prompt).toContain("Default timeout: 120s");
+    expect(prompt).toContain("Maximum timeout: 600s");
   });
 
-  it("falls back to seconds labels for non-minute-aligned values", () => {
-    const prompt = buildBashTimeoutPrompt({ defaultSeconds: 45, maxSeconds: 90 });
-    expect(prompt).toContain("Default timeout: 45s (45s)");
-    expect(prompt).toContain("Recommended maximum timeout: 90s (90s)");
+  it("states that values above the maximum are capped", () => {
+    const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 });
+    expect(prompt).toContain("Larger values are capped automatically");
   });
 
-  it("states max is advisory and includes long-running guidance", () => {
+  it("includes long-running command guidance", () => {
     const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 });
-    expect(prompt).toMatch(/advisory guidance, not a hard cap/);
     expect(prompt).toMatch(/long-running commands/i);
     expect(prompt).toContain("tmux");
   });

--- a/packages/pi-bash-timeout/src/timeout.test.ts
+++ b/packages/pi-bash-timeout/src/timeout.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  BASH_DEFAULT_TIMEOUT_SECONDS,
+  BASH_MAX_TIMEOUT_SECONDS,
+  buildBashTimeoutPrompt,
+  DEFAULT_TIMEOUT_ENV,
+  MAX_TIMEOUT_ENV,
+  resolveBashTimeoutDefaults,
+} from "./timeout.js";
+
+describe("resolveBashTimeoutDefaults", () => {
+  it("returns built-in constants when no flag or env is set", () => {
+    const result = resolveBashTimeoutDefaults({}, {});
+    expect(result).toEqual({
+      defaultSeconds: BASH_DEFAULT_TIMEOUT_SECONDS,
+      maxSeconds: BASH_MAX_TIMEOUT_SECONDS,
+    });
+  });
+
+  it("uses env vars when no flag is set", () => {
+    const result = resolveBashTimeoutDefaults(
+      {},
+      { [DEFAULT_TIMEOUT_ENV]: "30", [MAX_TIMEOUT_ENV]: "900" },
+    );
+    expect(result).toEqual({ defaultSeconds: 30, maxSeconds: 900 });
+  });
+
+  it("prefers flag over env (flag > env precedence)", () => {
+    const result = resolveBashTimeoutDefaults(
+      { default: "45", max: "300" },
+      { [DEFAULT_TIMEOUT_ENV]: "30", [MAX_TIMEOUT_ENV]: "900" },
+    );
+    expect(result).toEqual({ defaultSeconds: 45, maxSeconds: 300 });
+  });
+
+  it("falls through to env when a flag value is invalid", () => {
+    const result = resolveBashTimeoutDefaults(
+      { default: "garbage", max: "0" },
+      { [DEFAULT_TIMEOUT_ENV]: "30", [MAX_TIMEOUT_ENV]: "900" },
+    );
+    expect(result).toEqual({ defaultSeconds: 30, maxSeconds: 900 });
+  });
+
+  it("ignores invalid env values and falls back to built-in", () => {
+    const garbage = resolveBashTimeoutDefaults({}, { [DEFAULT_TIMEOUT_ENV]: "garbage" });
+    const zero = resolveBashTimeoutDefaults({}, { [DEFAULT_TIMEOUT_ENV]: "0" });
+    const negative = resolveBashTimeoutDefaults({}, { [MAX_TIMEOUT_ENV]: "-1" });
+    expect(garbage.defaultSeconds).toBe(BASH_DEFAULT_TIMEOUT_SECONDS);
+    expect(zero.defaultSeconds).toBe(BASH_DEFAULT_TIMEOUT_SECONDS);
+    expect(negative.maxSeconds).toBe(BASH_MAX_TIMEOUT_SECONDS);
+  });
+
+  it("ignores boolean flag values", () => {
+    const result = resolveBashTimeoutDefaults({ default: true, max: false }, {});
+    expect(result).toEqual({
+      defaultSeconds: BASH_DEFAULT_TIMEOUT_SECONDS,
+      maxSeconds: BASH_MAX_TIMEOUT_SECONDS,
+    });
+  });
+
+  it("raises max up to default when max is lower", () => {
+    const result = resolveBashTimeoutDefaults({ default: "500", max: "100" }, {});
+    expect(result).toEqual({ defaultSeconds: 500, maxSeconds: 500 });
+  });
+});
+
+describe("buildBashTimeoutPrompt", () => {
+  it("labels minute-aligned values in minutes", () => {
+    const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 });
+    expect(prompt).toContain("Default timeout: 120s (2 min)");
+    expect(prompt).toContain("Recommended maximum timeout: 600s (10 min)");
+  });
+
+  it("falls back to seconds labels for non-minute-aligned values", () => {
+    const prompt = buildBashTimeoutPrompt({ defaultSeconds: 45, maxSeconds: 90 });
+    expect(prompt).toContain("Default timeout: 45s (45s)");
+    expect(prompt).toContain("Recommended maximum timeout: 90s (90s)");
+  });
+
+  it("states max is advisory and includes long-running guidance", () => {
+    const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 });
+    expect(prompt).toMatch(/advisory guidance, not a hard cap/);
+    expect(prompt).toMatch(/long-running commands/i);
+    expect(prompt).toContain("tmux");
+  });
+});

--- a/packages/pi-bash-timeout/src/timeout.ts
+++ b/packages/pi-bash-timeout/src/timeout.ts
@@ -4,7 +4,7 @@ export const BASH_MAX_TIMEOUT_SECONDS = 600;
 export const DEFAULT_TIMEOUT_ENV = "PI_BASH_DEFAULT_TIMEOUT_SECONDS";
 export const MAX_TIMEOUT_ENV = "PI_BASH_MAX_TIMEOUT_SECONDS";
 
-export interface BashTimeoutDefaults {
+export interface BashTimeoutConfig {
   defaultSeconds: number;
   maxSeconds: number;
 }
@@ -35,10 +35,7 @@ function parsePositiveInt(value: boolean | string | undefined): number | undefin
  * Invalid or non-positive values at any layer are ignored and fall through.
  * `maxSeconds` is raised to `defaultSeconds` when it would otherwise be lower.
  */
-export function resolveBashTimeoutDefaults(
-  flags: BashTimeoutFlags,
-  env: EnvLike,
-): BashTimeoutDefaults {
+export function resolveBashTimeoutConfig(flags: BashTimeoutFlags, env: EnvLike): BashTimeoutConfig {
   const defaultSeconds =
     parsePositiveInt(flags.default) ??
     parsePositiveInt(env[DEFAULT_TIMEOUT_ENV]) ??
@@ -51,8 +48,12 @@ export function resolveBashTimeoutDefaults(
   return { defaultSeconds, maxSeconds };
 }
 
-export function buildBashTimeoutPrompt(defaults: BashTimeoutDefaults): string {
-  const minutes = (seconds: number): string =>
-    seconds % 60 === 0 ? `${seconds / 60} min` : `${seconds}s`;
-  return `\n## Bash Tool Timeout Policy\n\nThe \`bash\` tool enforces timeouts even when you omit the \`timeout\` parameter:\n\n- Default timeout: ${defaults.defaultSeconds}s (${minutes(defaults.defaultSeconds)}). Applied automatically when you do not set \`timeout\`.\n- Recommended maximum timeout: ${defaults.maxSeconds}s (${minutes(defaults.maxSeconds)}). This is advisory guidance, not a hard cap; explicit \`timeout\` values are preserved.\n- For long-running commands (builds, installs, test suites), set an explicit \`timeout\` that fits the workload. Do not assume commands run forever.\n- For commands that legitimately need to run beyond the recommended maximum, run them in the background via tmux or a similar mechanism instead of relying on bash timeout.\n`;
+export function buildBashTimeoutPrompt(defaults: BashTimeoutConfig): string {
+  return [
+    "Bash Tool Timeout Policy:",
+    `- Default timeout: ${defaults.defaultSeconds}s. Applied automatically when you do not set \`timeout\`.`,
+    `- Maximum timeout: ${defaults.maxSeconds}s. Larger values are capped automatically.`,
+    "- For long-running commands (builds, installs, test suites), set an explicit `timeout` that fits the workload. Do not assume commands run forever.",
+    "- For commands that legitimately need to run beyond the recommended maximum, run them in the background via tmux or a similar mechanism instead of relying on bash timeout.",
+  ].join("\n");
 }

--- a/packages/pi-bash-timeout/src/timeout.ts
+++ b/packages/pi-bash-timeout/src/timeout.ts
@@ -1,0 +1,58 @@
+export const BASH_DEFAULT_TIMEOUT_SECONDS = 120;
+export const BASH_MAX_TIMEOUT_SECONDS = 600;
+
+export const DEFAULT_TIMEOUT_ENV = "PI_BASH_DEFAULT_TIMEOUT_SECONDS";
+export const MAX_TIMEOUT_ENV = "PI_BASH_MAX_TIMEOUT_SECONDS";
+
+export interface BashTimeoutDefaults {
+  defaultSeconds: number;
+  maxSeconds: number;
+}
+
+export interface BashTimeoutFlags {
+  default?: boolean | string | undefined;
+  max?: boolean | string | undefined;
+}
+
+type EnvLike = Record<string, string | undefined>;
+
+function parsePositiveInt(value: boolean | string | undefined): number | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+/**
+ * Resolve timeout defaults with precedence: flag > env var > built-in constant.
+ *
+ * Flags are registered without a default, so `getFlag` returns `undefined` when
+ * the user did not pass one, letting the env var (senpi-mono compat) take over.
+ * Invalid or non-positive values at any layer are ignored and fall through.
+ * `maxSeconds` is raised to `defaultSeconds` when it would otherwise be lower.
+ */
+export function resolveBashTimeoutDefaults(
+  flags: BashTimeoutFlags,
+  env: EnvLike,
+): BashTimeoutDefaults {
+  const defaultSeconds =
+    parsePositiveInt(flags.default) ??
+    parsePositiveInt(env[DEFAULT_TIMEOUT_ENV]) ??
+    BASH_DEFAULT_TIMEOUT_SECONDS;
+  const rawMax =
+    parsePositiveInt(flags.max) ??
+    parsePositiveInt(env[MAX_TIMEOUT_ENV]) ??
+    BASH_MAX_TIMEOUT_SECONDS;
+  const maxSeconds = Math.max(rawMax, defaultSeconds);
+  return { defaultSeconds, maxSeconds };
+}
+
+export function buildBashTimeoutPrompt(defaults: BashTimeoutDefaults): string {
+  const minutes = (seconds: number): string =>
+    seconds % 60 === 0 ? `${seconds / 60} min` : `${seconds}s`;
+  return `\n## Bash Tool Timeout Policy\n\nThe \`bash\` tool enforces timeouts even when you omit the \`timeout\` parameter:\n\n- Default timeout: ${defaults.defaultSeconds}s (${minutes(defaults.defaultSeconds)}). Applied automatically when you do not set \`timeout\`.\n- Recommended maximum timeout: ${defaults.maxSeconds}s (${minutes(defaults.maxSeconds)}). This is advisory guidance, not a hard cap; explicit \`timeout\` values are preserved.\n- For long-running commands (builds, installs, test suites), set an explicit \`timeout\` that fits the workload. Do not assume commands run forever.\n- For commands that legitimately need to run beyond the recommended maximum, run them in the background via tmux or a similar mechanism instead of relying on bash timeout.\n`;
+}

--- a/packages/pi-bash-timeout/tsconfig.json
+++ b/packages/pi-bash-timeout/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,24 @@ importers:
         specifier: ^8.0.2
         version: 8.0.2(semantic-release@25.0.5(typescript@5.9.3))
 
+  packages/pi-bash-timeout:
+    devDependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      '@marcfargas/pi-test-harness':
+        specifier: ^0.6.1
+        version: 0.6.1(@earendil-works/pi-agent-core@0.75.5(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-ai@0.75.5(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.75.5(ws@8.21.0)(zod@4.4.3))
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
+
   packages/pi-caveman:
     devDependencies:
       '@earendil-works/pi-agent-core':


### PR DESCRIPTION
## Summary

- add `@piotr-oles/pi-bash-timeout` package
- inject default timeout into bash calls that omit one or pass a non-positive value
- cap explicit bash timeouts at configured maximum
- support pi flags and senpi-compatible env vars with flag > env > built-in precedence
- append bash timeout guidance to system prompt
- cover behavior with unit and pi test harness tests

## Configuration

| Setting | Flag | Env var | Default |
|---|---|---|---|
| Default timeout | `pi-bash-timeout-default` | `PI_BASH_DEFAULT_TIMEOUT_SECONDS` | `120s` |
| Maximum timeout | `pi-bash-timeout-max` | `PI_BASH_MAX_TIMEOUT_SECONDS` | `600s` |

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm check`
