### PR TITLE
Use bell signal on pi-plan review

### DIFF
--- a/packages/pi-plan/README.md
+++ b/packages/pi-plan/README.md
@@ -1,6 +1,6 @@
 # pi-plan
 
-A [pi coding agent](https://github.com/earendil-works/pi) extension that adds a `review-plan` tool — lets the agent write a named markdown plan to disk and present it in an interactive terminal widget for the user to approve, request changes, or ask a question before execution begins.
+A [pi coding agent](https://github.com/earendil-works/pi) extension that adds a `review_plan` tool — lets the agent write a named markdown plan to disk and present it in an interactive terminal widget for the user to approve, request changes, or ask a question before execution begins.
 
 ## Install
 
@@ -10,28 +10,28 @@ pi install npm:@piotr-oles/pi-plan
 
 ## Usage
 
-The extension registers a `review-plan` tool. The intended workflow is:
+The extension registers a `review_plan` tool. The intended workflow is:
 
 1. The agent writes the plan file using the built-in `write` tool (path under `~/.pi/plan/<repo>/<name>.md`)
-2. The agent calls `review-plan` with the relative path
+2. The agent calls `review_plan` with the relative path
 
 Instruct the agent to follow this pattern:
 
 ```
-Write the plan file to ~/.pi/plan/<repo>/<name>.md first, then call review-plan with the relative path.
+Write the plan file to ~/.pi/plan/<repo>/<name>.md first, then call review_plan with the relative path.
 ```
 
 Or reference it in a prompt template / skill file to enforce it project-wide.
 
 ## How it works
 
-When the agent calls `review-plan`:
+When the agent calls `review_plan`:
 
 1. Ensures `~/.pi/plan/` is a git repository (initialises it on first use)
 2. Commits the plan file with message `create: <name>.md`
 3. Hides the working indicator and shows an interactive widget with the following options:
    - **Open in [Editor]** *(shown when running inside Zed, VS Code, Cursor, or Windsurf)* — opens the plan file in your IDE so you can edit it; the widget stays open so you can still approve or request changes afterwards
-   - **Request changes** — edit the file then select this; the agent gets a diff of your edits and is told to update the plan, then call `review-plan` again
+   - **Request changes** — edit the file then select this; the agent gets a diff of your edits and is told to update the plan, then call `review_plan` again
    - **Approve** — edit the file (optionally) then select this; the agent gets a diff of any edits and is told to proceed with execution
    - **Ask question** — type a free-form question; the agent receives it and can reply before you decide
 
@@ -44,7 +44,7 @@ When the agent calls `review-plan`:
 | **Open in [Editor]** | Editor opens; widget re-shows with a `✓ Opened in …` confirmation. Agent is not notified. |
 | **Approve** (no edits) | `approve` result, empty diff — told to proceed |
 | **Approve** (with edits) | `approve` result + git diff — told to address comments, fix up plan, then proceed |
-| **Request changes** (with edits) | `request-changes` result + git diff — told to address comments, update plan, call `review-plan` again |
+| **Request changes** (with edits) | `request-changes` result + git diff — told to address comments, update plan, call `review_plan` again |
 | **Request changes** (no edits) | `request-changes` result, empty diff — told to ask the user what to change |
 | **Ask question** | `question` result with the question text |
 | **Esc / cancel** | `cancel` result |

--- a/packages/pi-plan/src/plan-tool.test.ts
+++ b/packages/pi-plan/src/plan-tool.test.ts
@@ -20,14 +20,17 @@ function makeExec() {
 }
 
 function makeCtx(customReturnValue: unknown) {
+  const abort = vi.fn();
   const setWorkingVisible = vi.fn();
   const custom =
     customReturnValue === null ? vi.fn() : vi.fn().mockResolvedValue(customReturnValue);
   return {
     ctx: {
       hasUI: customReturnValue !== null,
+      abort,
       ui: { setWorkingVisible, custom },
     },
+    abort,
     setWorkingVisible,
     custom,
   };
@@ -88,8 +91,8 @@ describe("createReviewPlanTool - execute with UI", () => {
     expect(custom).not.toHaveBeenCalled();
   });
 
-  it("returns cancel when user cancels", async () => {
-    const { ctx } = makeCtx({ type: "cancel" });
+  it("aborts and terminates when user cancels", async () => {
+    const { ctx, abort } = makeCtx({ type: "cancel" });
     const tool = createReviewPlanTool(makeExec(), plansDir);
 
     const result = await tool.execute(
@@ -100,6 +103,8 @@ describe("createReviewPlanTool - execute with UI", () => {
       ctx as any,
     );
 
+    expect(abort).toHaveBeenCalledOnce();
+    expect(result.terminate).toBe(true);
     expect(result.details.result).toBe("cancel");
     expect(result.content).toEqual([{ type: "text", text: "User cancelled plan review." }]);
   });
@@ -198,7 +203,7 @@ describe("createReviewPlanTool - execute with UI", () => {
         type: "text",
         text:
           "The changes mentioned above have already been saved in the plan file.\n" +
-          "Address user comments, fixup the plan, then ask user about next steps.",
+          "Address user comments, consolidate the plan if needed, then ask user about next steps.",
       },
     ]);
   });
@@ -303,6 +308,23 @@ describe("createReviewPlanTool - execute with UI", () => {
           "Address the comment, update the plan if needed, then call review_plan again.",
       },
     ]);
+  });
+
+  it("signals the agent host before showing UI", async () => {
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const { ctx } = makeCtx({ type: "approve" });
+    const tool = createReviewPlanTool(makeExec(), plansDir);
+
+    await tool.execute(
+      "id",
+      { planPath: "my-repo/plan.md" },
+      AbortSignal.timeout(5000),
+      undefined,
+      ctx as any,
+    );
+
+    expect(stdoutWrite).toHaveBeenCalledWith("\x07");
+    stdoutWrite.mockRestore();
   });
 
   it("hides working indicator before showing UI and restores it after", async () => {

--- a/packages/pi-plan/src/plan-tool.ts
+++ b/packages/pi-plan/src/plan-tool.ts
@@ -98,9 +98,11 @@ export function createReviewPlanTool(
       ctx.ui.setWorkingVisible(true);
 
       if (result.type === "cancel") {
+        ctx.abort();
         return {
           content: [{ type: "text", text: "User cancelled plan review." }],
           details: { result: "cancel", planPath },
+          terminate: true,
         };
       }
 
@@ -158,7 +160,7 @@ export function createReviewPlanTool(
                 type: "text",
                 text: [
                   "The changes mentioned above have already been saved in the plan file.",
-                  "Address user comments, fixup the plan, then ask user about next steps.",
+                  "Address user comments, consolidate the plan if needed, then ask user about next steps.",
                 ].join("\n"),
               },
             ],

--- a/packages/pi-plan/src/plan-tool.ts
+++ b/packages/pi-plan/src/plan-tool.ts
@@ -79,6 +79,8 @@ export function createReviewPlanTool(
       let editorOpened = false;
       let result: PlanWidgetAnswer;
 
+      // send bell signal to stdout to integrate with agent hosts
+      process.stdout.write("\x07");
       while (true) {
         result = await ctx.ui.custom<PlanWidgetAnswer>((tui, theme, _kb, done) => {
           const planWidget = new PlanWidget(tui, theme, planPath, editor, editorOpened);


### PR DESCRIPTION
IDEs like Zed listens for bell signal on stdout of the process to inform user that agent is done/blocked. 