### PR TITLE
Prevent late subagent updates after abort

### DIFF
--- a/packages/pi-subagents/src/domain/instance/running-subagent.ts
+++ b/packages/pi-subagents/src/domain/instance/running-subagent.ts
@@ -149,6 +149,10 @@ export class RunningSubagent {
   ): Promise<void> {
     const session = this.session;
     const unsubscribe = session.subscribe(async (event: AgentSessionEvent) => {
+      if (this.state.aborted) {
+        return;
+      }
+
       switch (event.type) {
         case "turn_end":
           this.state.turn++;

--- a/packages/pi-subagents/src/domain/subagent-store.ts
+++ b/packages/pi-subagents/src/domain/subagent-store.ts
@@ -112,9 +112,6 @@ export class SubagentStore {
         this.queued.delete(entry.instance.id);
         this.running.delete(entry.instance.id);
         const done = await entry.instance.abort();
-        if ((entry.instance as Subagent).status === "done") {
-          return;
-        }
         params.onDone(done);
         entry.instance = done;
         this.done.set(entry.instance.id, entry);

--- a/packages/pi-subagents/src/domain/subagent-store.ts
+++ b/packages/pi-subagents/src/domain/subagent-store.ts
@@ -78,17 +78,14 @@ export class SubagentStore {
         entry.instance = entry.instance.run({
           onUpdate: (running: RunningSubagent) => {
             if (entry.instance.status !== "running") {
-              throw new Error(`Cannot update non-running (${entry.instance.status}) subagent.`);
+              return;
             }
             params.onUpdate(running);
             entry.instance = running;
           },
           onDone: (done: DoneSubagent) => {
-            if (entry.instance.status === "done") {
-              return; // noop
-            }
             if (entry.instance.status !== "running") {
-              throw new Error(`Cannot mark done non-running (${entry.instance.status}) subagent.`);
+              return;
             }
             this.running.delete(entry.instance.id);
             params.onDone(done);
@@ -115,6 +112,9 @@ export class SubagentStore {
         this.queued.delete(entry.instance.id);
         this.running.delete(entry.instance.id);
         const done = await entry.instance.abort();
+        if ((entry.instance as Subagent).status === "done") {
+          return;
+        }
         params.onDone(done);
         entry.instance = done;
         this.done.set(entry.instance.id, entry);


### PR DESCRIPTION
## Motivation

An aborted subagent could still receive a delayed `pi-title` session-name event after its store entry became done. That late update threw `Cannot update non-running (done) subagent` as an unhandled rejection and caused pi to exit. This change treats callbacks received after a subagent stops running as stale and ignores them.

## Changes

- **Non-running subagents ignore stale callbacks.** Late session updates and completion callbacks no longer reach consumers or throw.
- **Aborted sessions stop handling events.** Late turn events cannot steer a session after abort starts.

## QA

No new automated tests were added. Existing package tests pass with `pnpm --filter @piotr-oles/pi-subagents test`; typecheck and Biome checks also pass.

To check by hand: 1. Start pi with `pi-subagents` and `pi-title` loaded. 2. Spawn a subagent, then abort it while its prompt or title generation is still finishing. 3. Wait for the delayed work to settle. Pi should stay open, subagent should remain done, and no `Cannot update non-running (done) subagent` error should appear.

## Blast Radius

Only `pi-subagents` abort and session-event handling changes. Checked update flow through `SubagentInstancesManager` and `subagent-tool`; `pi-title` is not changed. No public API change and no datastore migration.
