### PR TITLE
Add reusable terminal bell extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ Exposes `/title` command to manually regenerate title from recent session contex
 
 No flags — constants are hardcoded (`MAX_TITLE_LENGTH = 40`, `MIN_PROMPT_LENGTH = 60`).
 
+### `pi-bell` (`packages/pi-bell`)
+Sends a terminal bell (`\x07`) when an agent run with UI finishes. Guards on `ctx.hasUI`, so SDK-created subagents and other sessions without UI do not trigger host notifications. No configuration.
+
 ### `pi-reflag` (`packages/pi-reflag`)
 Intercepts `bash` tool calls and rewrites `grep` → `rg` (ripgrep) and `find` → `fd` transparently before execution. Shows a user-visible toast notification on rewrite - agent never sees it.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A monorepo of [pi coding agent](https://github.com/earendil-works/pi) extensions
 | [`@piotr-oles/pi-cwd`](packages/pi-cwd) | Reminds agent to use relative paths — detects absolute cwd paths in `read`/`write`/`edit`/`bash` calls and appends a tip to the tool result |
 | [`@piotr-oles/pi-subagents`](packages/pi-subagents) | Lets the agent spawn specialized subagents — each running in its own isolated session with its own model, tools, and instructions |
 | [`@piotr-oles/pi-title`](packages/pi-title) | Generates a short session title from the first user message using the active model |
+| [`@piotr-oles/pi-bell`](packages/pi-bell) | Sends a terminal bell when a UI agent run finishes. |
 | [`@piotr-oles/pi-pr`](packages/pi-pr) | Shows the current branch's GitHub PR in the footer — a clickable `#n` link plus a CI status dot, a merge-conflict alarm, and a review verdict, polled in the background |
 | [`@piotr-oles/pi-yagni`](packages/pi-yagni) | Injects YAGNI discipline into the system prompt — build the minimum that works, reuse before writing, no speculative code |
 

--- a/packages/pi-bell/README.md
+++ b/packages/pi-bell/README.md
@@ -1,0 +1,30 @@
+# pi-bell
+
+A [pi coding agent](https://github.com/earendil-works/pi) extension that sends a terminal bell when an interactive agent run finishes. Terminal hosts such as Zed can use the bell to notify you that pi is ready.
+
+## Install
+
+```bash
+pi install npm:@piotr-oles/pi-bell
+```
+
+## Usage
+
+No configuration. Bell is emitted after `agent_end` only when `ctx.hasUI` is true.
+
+Sessions without UI—including SDK-created subagent sessions, print mode, and JSON mode—do not emit a bell.
+
+## Development
+
+```bash
+pnpm install
+pnpm --filter @piotr-oles/pi-bell test
+pnpm --filter @piotr-oles/pi-bell typecheck
+pnpm --filter @piotr-oles/pi-bell check
+```
+
+To test extension manually:
+
+```bash
+pi -e packages/pi-bell/src/index.ts
+```

--- a/packages/pi-bell/package.json
+++ b/packages/pi-bell/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@piotr-oles/pi-bell",
+  "version": "0.0.0",
+  "description": "Pi Coding Agent extension: notify terminal hosts when an interactive agent finishes",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piotr-oles/pi-extensions.git",
+    "directory": "packages/pi-bell"
+  },
+  "keywords": [
+    "pi-package"
+  ],
+  "type": "module",
+  "files": [
+    "src",
+    "!src/*.test.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "biome ci src/",
+    "fix": "biome check --write src/",
+    "release": "semantic-release -e semantic-release-monorepo"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.75.5",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.1"
+  }
+}

--- a/packages/pi-bell/src/index.test.ts
+++ b/packages/pi-bell/src/index.test.ts
@@ -1,0 +1,50 @@
+import type {
+  AgentEndEvent,
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import piBell from "./index.js";
+
+type AgentEndHandler = (event: AgentEndEvent, ctx: ExtensionContext) => Promise<void> | void;
+
+function makeContext(hasUI: boolean): ExtensionContext {
+  return { hasUI } as ExtensionContext;
+}
+
+function captureAgentEndHandler(): AgentEndHandler {
+  let handler: AgentEndHandler | undefined;
+  const pi = {
+    on(event: string, registered: AgentEndHandler) {
+      if (event === "agent_end") {
+        handler = registered;
+      }
+    },
+  } as unknown as ExtensionAPI;
+
+  piBell(pi);
+  return handler!;
+}
+
+describe("pi-bell", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("does not ring when non-interactive agent finishes", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const onAgentEnd = captureAgentEndHandler();
+
+    await onAgentEnd({} as AgentEndEvent, makeContext(false));
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("rings terminal bell when interactive agent finishes", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const onAgentEnd = captureAgentEndHandler();
+
+    await onAgentEnd({} as AgentEndEvent, makeContext(true));
+
+    expect(write).toHaveBeenCalledOnce();
+    expect(write).toHaveBeenCalledWith("\x07");
+  });
+});

--- a/packages/pi-bell/src/index.ts
+++ b/packages/pi-bell/src/index.ts
@@ -1,0 +1,9 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function piBell(pi: ExtensionAPI): void {
+  pi.on("agent_end", (_event, ctx) => {
+    if (ctx.hasUI) {
+      process.stdout.write("\x07");
+    }
+  });
+}

--- a/packages/pi-bell/tsconfig.json
+++ b/packages/pi-bell/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,18 @@ importers:
         specifier: ^3.2.1
         version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
 
+  packages/pi-bell:
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.75.5
+        version: 0.75.5(ws@8.21.0)(zod@4.4.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
+
 packages:
 
   '@actions/core@3.0.1':


### PR DESCRIPTION
## Motivation

Bell behavior lived as a personal extension, which made it hard to test, document, install, or share. This change adds it as publishable `@piotr-oles/pi-bell` package so other pi users and terminal hosts such as Zed can use same completion signal.

## Changes

- **Added terminal bell extension.** It listens for `agent_end` and writes BEL (`\x07`) only when `ctx.hasUI` is true.
- **Added package setup and docs.** Workspace metadata supports testing, type-checking, publishing, and installation through pi.

## QA

Added tests for both paths: sessions with UI emit one bell, while sessions without UI emit none. To check by hand: 1. Run `pi -e packages/pi-bell/src/index.ts`, submit a prompt, and confirm terminal host receives bell when response ends. 2. Run `pi -p -e packages/pi-bell/src/index.ts "Reply with done"` and confirm print run finishes without bell.

## Blast Radius

Touches new `packages/pi-bell` package, workspace lockfile, and package catalogs in `README.md` and `AGENTS.md`. Existing extension code is unchanged. Checked `pi-subagents` SDK session creation and `pi-plan` bell producer; neither is changed. New package has no callers to migrate and no datastore migration.
