### PR TITLE
fix(reflag): split attached values in clustered short flags (-A3 -> -A 3)

### DIFF
--- a/packages/pi-reflag/src/grep.test.ts
+++ b/packages/pi-reflag/src/grep.test.ts
@@ -122,6 +122,12 @@ describe("context lines", () => {
     expect(t(["-A", "3", "hello", "file.txt"])).toEqual(["-A", "3", "hello", "file.txt"]);
   });
 
+  it("attached context value -A3 splits into flag + value", () => {
+    expect(t(["-A3", "pat", "file.txt"])).toEqual(["-A", "3", "pat", "file.txt"]);
+    expect(t(["-B3", "pat"])).toEqual(["-B", "3", "pat"]);
+    expect(t(["-C2", "pat"])).toEqual(["-C", "2", "pat"]);
+  });
+
   it("before context -B", () => {
     expect(t(["-B", "2", "hello", "file.txt"])).toEqual(["-B", "2", "hello", "file.txt"]);
   });

--- a/packages/pi-reflag/src/grep.ts
+++ b/packages/pi-reflag/src/grep.ts
@@ -211,8 +211,9 @@ export function translateGrepArgs(args: string[]): string[] | undefined {
     }
 
     if (arg.startsWith("-") && arg.length > 2 && !/^-\d/.test(arg)) {
-      for (const c of arg.slice(1)) {
-        const flag = `-${c}`;
+      const chars = arg.slice(1);
+      for (let j = 0; j < chars.length; j++) {
+        const flag = `-${chars[j]}`;
         if (DROP_SHORT.has(flag)) {
           continue;
         }
@@ -229,7 +230,18 @@ export function translateGrepArgs(args: string[]): string[] | undefined {
           translated.push(flag);
           continue;
         }
-
+        if (PASSTHROUGH_WITH_ARG.has(flag)) {
+          // attached value: -A3 → -A 3; bare flag at cluster end takes next arg
+          translated.push(flag);
+          if (j + 1 < chars.length) {
+            translated.push(chars.slice(j + 1));
+            j = chars.length;
+          } else if (i + 1 < args.length) {
+            i++;
+            translated.push(args[i]);
+          }
+          break;
+        }
         // unknown flag - bail
         return undefined;
       }


### PR DESCRIPTION
## Problem

`grep -A3` (attached value, no space) rewrites to invalid `rg -A -C 3` — the cluster loop pushes `-A` without consuming its value, then `-3` hits the numeric-context branch and becomes `-C 3`:

```
rg: error parsing flag -A: value is not a valid number: invalid digit found in string
```

Repro: any `grep` with attached context value, e.g. `echo "timeout 420" | grep "timeout" -A3 -B3`

## Fix

In the clustered-short-flag branch of `translateGrepArgs`: flags from `PASSTHROUGH_WITH_ARG` (`-A`/`-B`/`-C`/`-f`/`-m`) now split attached values (`-A3` → `-A 3`), or consume the next arg when at cluster end.

## Tests

- Added: attached values for `-A3`/`-B3`/`-C2`
- Full suite: 245 pass, 0 fail